### PR TITLE
Filtering out coverage tooling from jshint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,9 +42,17 @@ module.exports = function(grunt) {
                 "loopfunc": true, // allow functions to be defined in loops
                 "sub": true       // don't warn that foo['bar'] should be written as foo.bar
             },
-            all: [
-                '*/*.js'
-            ],
+            all: {
+                src: ['*/*.js'],
+                filter: function(filepath) { // on some developer machines the test coverage HTML report utilities cause further failures
+                    if(filepath.indexOf("coverage/prettify.js") === -1) {
+                        return true;   
+                    } else {
+                        console.log("Filtered out " + filepath + " from the jshint checks");
+                        return false;
+                    }
+                }
+            },
         },
         inlinelint: {
             html: ['*/*.html']


### PR DESCRIPTION
On some machines (like my laptop), when running the build, it fails the JSHint checks after test coverage report is produced in HTML mode by Istanbul. This is because Istanbul drops in coverage/prettify.js into the root of the project and prettify.js fails jshint.

It's annoying to delete the coverage report every time after finished inspecting it so I thought we shall blacklist it.
