### PR TITLE
Adding metadata to Instagram payload

### DIFF
--- a/instagram/instagram.html
+++ b/instagram/instagram.html
@@ -86,6 +86,9 @@
     photos the user has liked. Each message sent by the node contains a single
     photo in its payload, either as a Buffer containing the photo or its URL.</p>
     
+    <p>When the metadata is available within Instagram's service, the photo's capture time and location
+    are also forwarded in the form of msg.time, msg.lat and msg.lon.</p>
+    
     <p>Videos are currently not supported and are ignored.</p>
 </script>
 
@@ -122,6 +125,9 @@
     <p>It can be configured to either retrieve new photos uploaded by the user, or
     photos the user has liked. Each message sent by the node contains a single
     photo in its payload, either as a Buffer containing the photo or its URL.</p>
+    
+    <p>When the metadata is available within Instagram's service, the photo's capture time and location
+    are also forwarded in the form of msg.time, msg.lat and msg.lon.</p>
     
     <p>Videos are currently not supported and are ignored.</p>
 </script>

--- a/instagram/instagram.js
+++ b/instagram/instagram.js
@@ -29,7 +29,6 @@ module.exports = function(RED) {
     
     function InstagramCredentialsNode(n) {
         RED.nodes.createNode(this,n);
-//        this.clientID = n.clientID;
     }
     
     function downloadImageAndSendAsBuffer(node, url, msg) {
@@ -112,7 +111,7 @@ module.exports = function(RED) {
             }
             
             if(medias) {
-                for(var i = 0; i < medias.length; i++) {                    
+                for(var i = 0; i < medias.length; i++) {
                     if (node.inputType === "like") { // like is a special case as per Instagram API behaviour
                         if(areWeInPaginationRecursion === false) { // need to set the pointer of latest served liked image before pagination occurs
                             idOfLikedReturned = medias[0].id;
@@ -132,6 +131,20 @@ module.exports = function(RED) {
                      //deliberate no-op
                     } else if(medias[i].type === IMAGE) {
                         var url = medias[i].images.standard_resolution.url;
+
+                        if(medias[i].location) {
+                            if(medias[i].location.latitude) {
+                                msg.lat = medias[i].location.latitude;
+                            }
+                            if(medias[i].location.longitude) {
+                                msg.lon = medias[i].location.longitude;
+                            }
+                        }
+                        
+                        if(medias[i].created_time) {
+                            msg.time = new Date(medias[i].created_time * 1000);
+                        }
+                        
                         if (node.outputType === "link") {
                             msg.payload = url;
                             node.send(msg);


### PR DESCRIPTION
I'm adding msg.time, msg.lat, msg.lon properties to the outgoing message of the Instagram node, should this be available. The change enables us to use the Instagram node in location-based scenarios. Closes  issue #6 
