### PR TITLE
Simple pinboard tests and minor fix

### DIFF
--- a/pinboard/pinboard.js
+++ b/pinboard/pinboard.js
@@ -44,6 +44,7 @@ module.exports = function(RED) {
                 }
                 if (!msg.title) {
                     node.warn("msg.title must be provided");
+                    return;
                 }
                 var options = {
                     hostname: "api.pinboard.in",

--- a/test/pinboard/pinboard_spec.js
+++ b/test/pinboard/pinboard_spec.js
@@ -29,13 +29,50 @@ describe('pinboard nodes', function() {
     });
 
     describe('out node', function() {
-        it('can be loaded', function(done) {
-            helper.load(pinboardNode,
-                        [{id:"pinboard", type:"pinboard out"}], function() {
-                var pinboard = helper.getNode("pinboard");
-                pinboard.should.have.property('id', 'pinboard');
-                done();
-            });
-        });
+        it(' logs a warning if msg.payload is not set', function(done) {
+            helper.load(pinboardNode, 
+                [ {id:"inject", type:"helper", wires:[["pinboard"]]},
+                  {id:"del-user", type:"pinboard-user", username:"Bob Jones"},
+                  {id:"pinboard", type:"pinboard out", user:"del-user", private:true, tags:"testtag"}], 
+                  {
+                    "del-user": {
+                        password:"abcd1234"
+                    },
+                  },
+                  function() {
+                      var inject = helper.getNode("inject");
+                      var pinboard = helper.getNode("pinboard");
+                      pinboard.should.have.property('id','pinboard');
+                      pinboard.on('log',function(obj) {
+                          should.deepEqual({level:"warn", id:pinboard.id,
+                                            type:pinboard.type, msg:"url must be provided in msg.payload"}, obj);
+                          done();
+                      });
+                      inject.send({title:"test",description:"testdesc"});
+                  });
+    })
+        
+        it(' logs a warning if msg.title is not set', function(done) {
+            helper.load(pinboardNode, 
+                [ {id:"inject", type:"helper", wires:[["pinboard"]]},
+                  {id:"del-user", type:"pinboard-user", username:"Bob Jones"},
+                  {id:"pinboard", type:"pinboard out", user:"del-user", private:true, tags:"testtag"}], 
+                  {
+                    "del-user": {
+                        password:"abcd1234"
+                    },
+                  },
+                  function() {
+                      var inject = helper.getNode("inject");
+                      var pinboard = helper.getNode("pinboard");
+                      pinboard.should.have.property('id','pinboard');
+                      pinboard.on('log',function(obj) {
+                          should.deepEqual({level:"warn", id:pinboard.id,
+                                            type:pinboard.type, msg:"msg.title must be provided"}, obj);
+                          done();
+                      });
+                      inject.send({payload:"foobar",description:"testdesc"});
+                  });
+        })
     });
 });


### PR DESCRIPTION
Noticed that the pinboard node is similar to the delicious one. Therefore added a couple of the basic "if this property isn't set" type tests along with adding the missing "return" statement in the node itself in the same way as with the delicious node.

Still more tests that can be done here. Ones that use "nock" to mock the calls but they can be added as and when (just copy the delicious ones). Plus I don't have a pinboard account which can be used to find the api calls and results to mock.
