### PR TITLE
Updated README. Typo

### DIFF
--- a/strava/README.md
+++ b/strava/README.md
@@ -1,4 +1,4 @@
-node-red-node-flickr
+node-red-node-strava
 ====================
 
 A <a href="http://nodered.org" target="_new">Node-RED</a> node to get your latest


### PR DESCRIPTION
Cut 'n' paste typo, says _flickr_ instead of _strava_