### PR TITLE
Updates to web-nodes to ignore Eclipse users and fix default JSHint found warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-node_modules
 .npm
+.jshintignore
+.jshintrc
+.project
+.settings
+.tern-project
 coverage
+node_modules
+npm_debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.settings
+.jshintignore
+.jshintrc
+.project
+.tern-project
+.travis.yml
+.git

--- a/delicious/delicious.js
+++ b/delicious/delicious.js
@@ -57,13 +57,13 @@ module.exports = function(RED) {
                         user: node.user.username,
                         password: node.user.credentials.password
                     }
-                }
+                };
                 // TODO: allow tags to be added by the message 
                 if (node.tags) {
-                    options.url += "&tags="+encodeURIComponent(node.tags)
+                    options.url += "&tags="+encodeURIComponent(node.tags);
                 }
                 if (msg.description) {
-                    options.url += "&extended="+encodeURIComponent(msg.description)
+                    options.url += "&extended="+encodeURIComponent(msg.description);
                 }
                 
                 node.status({fill:"blue",shape:"dot",text:"saving"});
@@ -93,4 +93,4 @@ module.exports = function(RED) {
         
     }
     RED.nodes.registerType("delicious out",DeliciousOutNode);
-}
+};

--- a/fitbit/fitbit.js
+++ b/fitbit/fitbit.js
@@ -398,4 +398,4 @@ module.exports = function(RED) {
             }
         );
     });
-}
+};

--- a/flickr/flickr.js
+++ b/flickr/flickr.js
@@ -73,7 +73,7 @@ module.exports = function(RED) {
                 if (Buffer.isBuffer(msg.payload)) {
                     var options = {
                         api_key:"e99784b8ff80eaabc9c096b22e517c13"
-                    }
+                    };
                     if (msg.title) {
                         options.title = RED.util.ensureString(msg.title);
                     }
@@ -88,7 +88,7 @@ module.exports = function(RED) {
                             tags = msg.tags.join(" ");
                         }
                         if (node.tags) {
-                            tags += (tags.length > 0 ? " ":"")+node.tags
+                            tags += (tags.length > 0 ? " ":"")+node.tags;
                         }
                         options.tags = tags;
                     }
@@ -160,11 +160,11 @@ module.exports = function(RED) {
                 '<p>Something went wrong with the authentication process. The following error was returned:<p>'+
                 '<p><b>'+error.statusCode+'</b>: '+error.data+'</p>'+
                 '<p>One known cause of this type of failure is if the clock is wrong on system running Node-RED.';
-                res.send(resp)
+                res.send(resp);
             } else {
                 credentials.oauth_token = oauth_token;
                 credentials.oauth_token_secret = oauth_token_secret;
-                res.redirect('https://www.flickr.com/services/oauth/authorize?oauth_token='+oauth_token)
+                res.redirect('https://www.flickr.com/services/oauth/authorize?oauth_token='+oauth_token);
                 RED.nodes.addCredentials(req.params.id,credentials);
             }
         });
@@ -199,4 +199,4 @@ module.exports = function(RED) {
             }
         );
     });
-}
+};

--- a/foursquare/foursquare.js
+++ b/foursquare/foursquare.js
@@ -247,7 +247,7 @@ module.exports = function(RED) {
                              var resp = '<h2>Oh no!</h2>'+
                              '<p>Something went wrong with the authentication process. The following error was returned:</p>'+
                              '<p><b>'+error.statusCode+'</b>: '+error.data+'</p>';
-                             res.send(resp)
+                             res.send(resp);
                          } else {
                              var apiUrl = "https://api.foursquare.com/v2/users/self?oauth_token=" + oauth_access_token  + "&v=20141016";
                              var r = request.get(apiUrl,function(err, httpResponse, body) {
@@ -255,14 +255,14 @@ module.exports = function(RED) {
                                      var resp = '<h2>Oh no!</h2>'+
                                      '<p>Something went wrong with the authentication process. The following error was returned:</p>'+
                                      '<p><b>'+err.statusCode+'</b>: '+err.data+'</p>';
-                                     res.send(resp)
+                                     res.send(resp);
                                  } else {
                                      var result = JSON.parse(body);
                                      if (result.meta.code != 200) {
                                          var message = '<h2>Oh no!</h2>'+
                                          '<p>Something went wrong with the authentication process. Http return code:</p>'+
                                          '<p><b>'+result.meta.code+'</b></p>';
-                                         res.send(message)                                         
+                                         res.send(message);
                                      } else {
                                          credentials = {};
                                          credentials.displayname = result.response.user.firstName + " " + result.response.user.lastName;
@@ -280,4 +280,4 @@ module.exports = function(RED) {
 
     });
     
-}
+};

--- a/foursquare/swarm.js
+++ b/foursquare/swarm.js
@@ -150,4 +150,4 @@ module.exports = function(RED) {
             }
         });
     }
-}
+};

--- a/google/calendar.js
+++ b/google/calendar.js
@@ -585,4 +585,4 @@ module.exports = function(RED) {
         });
     }
     RED.nodes.registerType("google calendar out", GoogleCalendarOutNode);
-}
+};

--- a/jawboneup/jawboneup.js
+++ b/jawboneup/jawboneup.js
@@ -67,7 +67,7 @@ module.exports = function(RED) {
                       headers: {
                           "Authorization":"Bearer  " + credentials.accesstoken
                       }
-              }
+              };
               var r = request.get(options,function(err, httpResponse, body) {
                   if (err) {
                       node.error(err.toString(),msg);
@@ -216,13 +216,13 @@ module.exports = function(RED) {
                              var resp = '<h2>Oh no!</h2>'+
                              '<p>Something went wrong with the authentication process. The following error was returned:</p>'+
                              '<p><b>'+error.statusCode+'</b>: '+error.data+'</p>';
-                             res.send(resp)
+                             res.send(resp);
                          } else {
                              if (results.error) {
                                  var response = '<h2>Oh no!</h2>'+
                                  '<p>Something went wrong with the authentication process. The following error was returned:</p>'+
                                  '<p><b>'+results.error+'</b>: '+results.error_description+'</p>';
-                                 res.send(response)
+                                 res.send(response);
                             } else {
                                 // note the extra whitespace after "Bearer" is required otherwise api call will return 401
                                 var options = {
@@ -230,20 +230,20 @@ module.exports = function(RED) {
                                         headers: {
                                             "Authorization":"Bearer  " + oauth_access_token
                                         }
-                                    }
+                                    };
                                 var r = request.get(options,function(err, httpResponse, body) {
                                     if (err) {
                                         var resp = '<h2>Oh no!</h2>'+
                                         '<p>Something went wrong with the authentication process. The following error was returned:</p>'+
                                         '<p><b>'+err.statusCode+'</b>: '+err.data+'</p>';
-                                        res.send(resp)
+                                        res.send(resp);
                                     } else {
                                         var result = JSON.parse(body);
                                         if (result.meta.code != 200) {
                                             var message = '<h2>Oh no!</h2>'+
                                             '<p>Something went wrong with the authentication process. Http return code:</p>'+
                                             '<p><b>'+result.meta.code+'</b></p>';
-                                            res.send(message)                                         
+                                            res.send(message);                                         
                                         } else {
                                             credentials = {};
                                             credentials.displayname = result.data.first + " " + result.data.last;
@@ -263,4 +263,4 @@ module.exports = function(RED) {
 
     });
     
-}
+};

--- a/pinboard/pinboard.js
+++ b/pinboard/pinboard.js
@@ -58,13 +58,13 @@ module.exports = function(RED) {
                     headers: {
                         "Accept":"application/json"
                     }
-                }
+                };
                 // TODO: allow tags to be added by the message 
                 if (node.tags) {
-                    options.path += "&tags="+encodeURIComponent(node.tags)
+                    options.path += "&tags="+encodeURIComponent(node.tags);
                 }
                 if (msg.description) {
-                    options.path += "&extended="+encodeURIComponent(msg.description)
+                    options.path += "&extended="+encodeURIComponent(msg.description);
                 }
                 
                 node.status({fill:"blue",shape:"dot",text:"saving"});
@@ -95,4 +95,4 @@ module.exports = function(RED) {
         
     }
     RED.nodes.registerType("pinboard out",PinboardOutNode);
-}
+};

--- a/strava/strava.js
+++ b/strava/strava.js
@@ -92,7 +92,7 @@ module.exports = function(RED) {
                 }
                 if(result.statusCode !== 200) {
                     console.log(data);
-                    return callback(null,result.statusCode)
+                    return callback(null,result.statusCode);
                 }
                 
                 activityDetails = data;

--- a/test/box/box_spec.js
+++ b/test/box/box_spec.js
@@ -35,7 +35,9 @@ describe('box nodes', function() {
     });
 
     describe("box credentials", function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it("should complete oauth dance", function(done) {
             helper.load(boxNode, [
                 {id:"input", type:"helper", wires:[["input"]]},
@@ -74,14 +76,18 @@ describe('box nodes', function() {
                     .expect(302)
                     .expect('Location', /https:\/\/app\.box\.com\/api\/oauth2\/authorize\?response_type=code&client_id=CLIENT&state=([^&]*)&redirect_uri=http%3A%2F%2Flocalhost%3A1880%2Fbox-credentials%2Fauth%2Fcallback/)
                     .end(function(err, res) {
-                        if (err) return done(err);
+                        if (err) {
+                        	return done(err);
+                        }
                         var location = url.parse(res.headers.location, true);
                         var state = location.query.state;
                         helper.request()
                             .get('/box-credentials/auth/callback?code=CODE&state='+state)
                             .expect(200)
                             .end(function(err, res) {
-                                if (err) return done(err);
+                                if (err) {
+                                	return done(err);
+                                }
                                 helper.credentials.get("box-config")
                                     .should.have.property('displayName','Foo Bar');
                                 done();
@@ -92,7 +98,9 @@ describe('box nodes', function() {
     });
 
     describe("watch node", function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it('should report file add event', function(done) {
             nock('https://api.box.com:443')
                 .get('/2.0/events?stream_position=now&stream_type=changes')
@@ -227,9 +235,10 @@ describe('box nodes', function() {
                     });
                 });
         });
-        return; // TODO: finish below
+        
+        // TODO: finish below tests
 
-        it('should report no event when filepattern does not match', function(done) {
+        it.skip('should report no event when filepattern does not match', function(done) {
             nock('https://api.box.com:443')
                 .post('/1/delta')
                 .reply(200, {
@@ -295,7 +304,7 @@ describe('box nodes', function() {
                 });
         });
 
-        it('should report event when filepattern matches', function(done) {
+        it.skip('should report event when filepattern matches', function(done) {
             nock('https://api.box.com:443')
                 .post('/1/delta')
                 .reply(200, {
@@ -359,7 +368,7 @@ describe('box nodes', function() {
                 });
         });
 
-        it('should report file delete event', function(done) {
+        it.skip('should report file delete event', function(done) {
             nock('https://api.box.com:443')
                 .post('/1/delta')
                 .reply(200, {
@@ -427,7 +436,9 @@ describe('box nodes', function() {
     });
 
     describe("query node", function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it('should fetch file', function(done) {
             nock('https://api.box.com:443')
                 .get('/2.0/folders/0')
@@ -513,7 +524,9 @@ describe('box nodes', function() {
     });
 
     describe('out node', function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it('should upload msg.payload', function(done) {
             nock('https://api.box.com:443')
                 .post('/oauth2/token',

--- a/test/delicious/delicious_spec.js
+++ b/test/delicious/delicious_spec.js
@@ -66,7 +66,7 @@ describe('delicious nodes', function() {
                           }
                       },200);
                   });
-        })
+        });
         
         it(' logs a warning if msg.title is not set', function(done) {
             helper.load(deliciousNode, 
@@ -99,7 +99,7 @@ describe('delicious nodes', function() {
                           }
                       },200);
                   });
-        })
+        });
         
         if (nock) {
             
@@ -116,7 +116,7 @@ describe('delicious nodes', function() {
                           function() {
                               var scope = nock('https://api.delicious.com:443')
                                   .get('/v1/posts/add?url=foobar&description=test&auth_token=undefined&shared=no&tags=testtag&extended=testdesc')
-                                    .reply(200, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\<code=\"done\"/>");
+                                    .reply(200, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><code=\"done\"/>");
                              
                               var inject = helper.getNode("inject");
                               var delicious = helper.getNode("delicious");
@@ -130,7 +130,7 @@ describe('delicious nodes', function() {
                                   return;
                               });
                           });
-            })
+            });
             
             it(' fails if failure with save link', function(done) {
                     helper.load(deliciousNode, 
@@ -145,7 +145,7 @@ describe('delicious nodes', function() {
                           function() {
                               var scope = nock('https://api.delicious.com:443')
                                   .get('/v1/posts/add?url=foobar&description=test&auth_token=undefined&shared=no&tags=testtag&extended=testdesc')
-                                    .reply(401, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\<code=\"access denied\"/>");
+                                    .reply(401, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><code=\"access denied\"/>");
                              
                               var inject = helper.getNode("inject");
                               var delicious = helper.getNode("delicious");
@@ -161,9 +161,9 @@ describe('delicious nodes', function() {
                               });
                               inject.send({payload:"foobar", title:"test",description:"testdesc"});
                           });
-            })
+            });
             
             
-        };
+        }
     });
 });

--- a/test/dropbox/dropbox_spec.js
+++ b/test/dropbox/dropbox_spec.js
@@ -40,7 +40,9 @@ describe('dropbox nodes', function() {
     });
 
     describe("watch node", function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it('should report file add event', function(done) {
             nock('https://api.dropbox.com:443')
                 .post('/1/delta')
@@ -357,7 +359,9 @@ describe('dropbox nodes', function() {
     });
 
     describe("query node", function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it('should fetch file', function(done) {
             nock('https://api-content.dropbox.com:443')
                 .get('/1/files/auto/foo.txt')
@@ -399,7 +403,9 @@ describe('dropbox nodes', function() {
     });
 
     describe('out node', function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it('should upload msg.payload', function(done) {
             nock('https://api.dropbox.com:443')
                 .get('/1/account/info')

--- a/test/fitbit/fitbit_spec.js
+++ b/test/fitbit/fitbit_spec.js
@@ -496,12 +496,16 @@ describe('fitbit nodes', function() {
                         .expect(302)
                         .expect('Location', 'https://www.fitbit.com/oauth/authorize?oauth_token=0123')
                         .end(function(err, res) {
-                            if (err) return done(err);
+                            if (err) {
+                            	return done(err);
+                            }
                             helper.request()
                                 .get('/fitbit-credentials/fitbit-config/auth/callback?oauth_verifier=abcdef')
                                 .expect(200)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     helper.credentials.get("fitbit-config")
                                         .should.have.property('username',
                                                               'Foo Bar');
@@ -729,7 +733,9 @@ describe('fitbit nodes', function() {
                         .get('/fitbit-credentials/fitbit-config/auth?client_key=0123&client_secret=4567&callback=http://localhost:1880/fitbit-credentials/fitbit-config/auth/callback')
                         .expect(200)
                         .end(function(err, res) {
-                            if (err) return done(err);
+                            if (err) {
+                            	return done(err);
+                            }
                             res.text.should.containEql('Oh no');
                             done();
                         });
@@ -769,12 +775,16 @@ describe('fitbit nodes', function() {
                         .expect(302)
                         .expect('Location', 'https://www.fitbit.com/oauth/authorize?oauth_token=0123')
                         .end(function(err, res) {
-                            if (err) return done(err);
+                            if (err) {
+                            	return done(err);
+                            }
                             helper.request()
                                 .get('/fitbit-credentials/fitbit-config/auth/callback?oauth_verifier=abcdef')
                                 .expect(200)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.containEql('Oh no');
                                     res.text.should.containEql('oauth_problem=permission_denied');
                                     done();
@@ -825,12 +835,16 @@ describe('fitbit nodes', function() {
                         .expect(302)
                         .expect('Location', 'https://www.fitbit.com/oauth/authorize?oauth_token=0123')
                         .end(function(err, res) {
-                            if (err) return done(err);
+                            if (err) {
+                            	return done(err);
+                            }
                             helper.request()
                                 .get('/fitbit-credentials/fitbit-config/auth/callback?oauth_verifier=abcdef')
                                 .expect(200)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.containEql('Oh no');
                                     res.text.should.containEql('No user found');
                                     done();
@@ -861,7 +875,9 @@ describe('fitbit nodes', function() {
                     .get('/fitbit-credentials/fitbit-config/auth?client_key=0123')
                     .expect(400)
                     .end(function(err, res) {
-                        if (err) return done(err);
+                        if (err) {
+                        	return done(err);
+                        }
                         done();
                     });
             });

--- a/test/foursquare/foursquare_spec.js
+++ b/test/foursquare/foursquare_spec.js
@@ -56,13 +56,17 @@ describe('foursquare nodes', function() {
                                     .get('/foursquare-credentials/auth?id=n4&clientid=abcdefg&clientsecret=mnopqrs&response_type=code&callback=http://localhost:1880:/foursquare-credentials')
                                     .expect(302)
                                     .end(function(err, res) {
-                                        if (err) return done(err);
+                                        if (err) {
+                                        	return done(err);
+                                        }
                                         var state = res.text.split("state=n4%253A");
                                         helper.request()
                                             .get('/foursquare-credentials/auth/callback?code=123456&state=n4:'+state[1])
                                             .expect(200)
                                             .end(function(err, res) {
-                                                if (err) return done(err);
+                                                if (err) {
+                                                	return done(err);
+                                                }
                                                 helper.credentials.get("n4")
                                                     .should.have.property('displayname',
                                                                           'John Smith');
@@ -98,13 +102,17 @@ describe('foursquare nodes', function() {
                             .get('/foursquare-credentials/auth?id=n4&clientid=abcdefg&clientsecret=mnopqrs&response_type=code&callback=http://localhost:1880:/foursquare-credentials')
                             .expect(302)
                             .end(function(err, res) {
-                                if (err) return done(err);
+                                if (err) {
+                                	return done(err);
+                                }
                               var state = res.text.split("state=n4%253A");
                               helper.request()
                                   .get('/foursquare-credentials/auth/callback?code=123456&state=n4:'+state[1])
                                   .expect(200)
                                   .end(function(err, res) {
-                                      if (err) return done(err);
+                                      if (err) {
+                                    	  return done(err);
+                                      }
                                       res.text.should.containEql('Oh no');
                                       done();
                                   });
@@ -131,13 +139,17 @@ describe('foursquare nodes', function() {
                                     .get('/foursquare-credentials/auth?id=n4&clientid=abcdefg&clientsecret=mnopqrs&response_type=code&callback=http://localhost:1880:/foursquare-credentials')
                                     .expect(302)
                                     .end(function(err, res) {
-                                        if (err) return done(err);
+                                        if (err) {
+                                        	return done(err);
+                                        }
                                         var state = res.text.split("state=n4%253A");
                                         helper.request()
                                             .get('/foursquare-credentials/auth/callback?code=123456&state=n4:'+state[1])
                                             .expect(200)
                                             .end(function(err, res) {
-                                                if (err) return done(err);
+                                                if (err) {
+                                                	return done(err);
+                                                }
                                                 res.text.should.containEql('Http return code');
                                                 done();
                                             });
@@ -160,12 +172,16 @@ describe('foursquare nodes', function() {
                                 .get('/foursquare-credentials/auth?id=n4&clientid=abcdefg&clientsecret=mnopqrs&response_type=code&callback=http://localhost:1880:/foursquare-credentials')
                                 .expect(302)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     helper.request()
                                         .get('/foursquare-credentials/auth/callback?code=123456&state=n4:13579')
                                         .expect(401)
                                         .end(function(err, res) {
-                                            if (err) return done(err);
+                                            if (err) {
+                                            	return done(err);
+                                            }
                                             res.text.should.containEql('CSRF token mismatch, possible cross-site request forgery attempt');
                                             done();
                                         });

--- a/test/google/calendar_spec.js
+++ b/test/google/calendar_spec.js
@@ -29,7 +29,7 @@ function TimeOffset(offsetSeconds) {
 }
 
 function ISOTimeString(offsetSeconds) {
-    return TimeOffset(offsetSeconds).toISOString();
+    return new TimeOffset(offsetSeconds).toISOString();
 }
 
 describe('google calendar nodes', function() {
@@ -48,19 +48,18 @@ describe('google calendar nodes', function() {
     describe('input node', function() {
         if (!nock) { return; }
         it('injects message for calendar entry', function(done) {
-            var oneMinuteAgo = TimeOffset(-60); // definitely passed
-            var now = TimeOffset();
-            var oneSecondFromNow = TimeOffset(1);
-            var oneMinuteFromNow = TimeOffset(60);
-            var oneMinuteOneSecondFromNow = TimeOffset(61);
-            var twoMinutesFromNow = TimeOffset(120);
+            var oneMinuteAgo = new TimeOffset(-60); // definitely passed
+            var now = new TimeOffset();
+            var oneSecondFromNow = new TimeOffset(1);
+            var oneMinuteFromNow = new TimeOffset(60);
+            var oneMinuteOneSecondFromNow = new TimeOffset(61);
+            var twoMinutesFromNow = new TimeOffset(120);
             var scope = nock('https://www.googleapis.com:443')
                 .filteringPath(function(path) {
                     path = path.replace(/\.\d\d\dZ$/g, '.000Z');
                     path =
                         path.replace(
-                            'timeMin='
-                              +encodeURIComponent(oneMinuteAgo.toISOString()),
+                            'timeMin=' + encodeURIComponent(oneMinuteAgo.toISOString()),
                             'timeMin=oneMinuteAgo');
                     [now, oneSecondFromNow].forEach(function(t) {
                         path =
@@ -211,19 +210,18 @@ describe('google calendar nodes', function() {
         });
 
         it('injects message for calendar entry based on end time', function(done) {
-            var oneMinuteAgo = TimeOffset(-60); // definitely passed
-            var now = TimeOffset();
-            var oneSecondFromNow = TimeOffset(1);
-            var oneMinuteFromNow = TimeOffset(60);
-            var oneMinuteOneSecondFromNow = TimeOffset(61);
-            var twoMinutesFromNow = TimeOffset(120);
+            var oneMinuteAgo = new TimeOffset(-60); // definitely passed
+            var now = new TimeOffset();
+            var oneSecondFromNow = new TimeOffset(1);
+            var oneMinuteFromNow = new TimeOffset(60);
+            var oneMinuteOneSecondFromNow = new TimeOffset(61);
+            var twoMinutesFromNow = new TimeOffset(120);
             var scope = nock('https://www.googleapis.com:443')
                 .filteringPath(function(path) {
                     path = path.replace(/\.\d\d\dZ$/g, '.000Z');
                     path =
                         path.replace(
-                            'timeMin='
-                              +encodeURIComponent(oneMinuteAgo.toISOString()),
+                            'timeMin=' + encodeURIComponent(oneMinuteAgo.toISOString()),
                             'timeMin=oneMinuteAgo');
                     [now, oneSecondFromNow].forEach(function(t) {
                         path =
@@ -378,9 +376,9 @@ describe('google calendar nodes', function() {
     describe('query node', function() {
         if (!nock) { return; }
         it('returns calendar entry', function(done) {
-            var oneHourAgo = TimeOffset(-3600);
-            var oneHourFromNow = TimeOffset(3600);
-            var twoHoursFromNow = TimeOffset(7200);
+            var oneHourAgo = new TimeOffset(-3600);
+            var oneHourFromNow = new TimeOffset(3600);
+            var twoHoursFromNow = new TimeOffset(7200);
             nock('https://www.googleapis.com:443')
                 .get('/calendar/v3/users/me/calendarList')
                 .reply(200, {

--- a/test/google/google_spec.js
+++ b/test/google/google_spec.js
@@ -35,7 +35,9 @@ describe('google nodes', function() {
     });
 
     describe("google credentials", function() {
-        if (!nock) return;
+        if (!nock) {
+        	return;
+        }
         it("should complete oauth dance", function(done) {
             helper.load(googleNode, [
                 {id:"google-config", type:"google-credentials"},
@@ -61,14 +63,18 @@ describe('google nodes', function() {
                     .expect(302)
                     .expect('Location', /https:\/\/accounts\.google\.com\/o\/oauth2\/auth\?response_type=code&client_id=CLIENT&state=([^&]*)&access_type=offline&approval_prompt=force&scope=profile%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.login%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.me%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.me%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&redirect_uri=http%3A%2F%2Flocalhost%3A1880%2Fgoogle-credentials%2Fauth%2Fcallback/)
                     .end(function(err, res) {
-                        if (err) return done(err);
+                        if (err) {
+                        	return done(err);
+                        }
                         var location = url.parse(res.headers.location, true);
                         var state = location.query.state;
                         helper.request()
                             .get('/google-credentials/auth/callback?code=CODE&state='+state)
                             .expect(200)
                             .end(function(err, res) {
-                                if (err) return done(err);
+                                if (err) {
+                                	return done(err);
+                                }
                                 helper.credentials.get("google-config")
                                     .should.have.property('displayName','Foo Bar');
                                 done();

--- a/test/instagram/instagram_spec.js
+++ b/test/instagram/instagram_spec.js
@@ -84,7 +84,9 @@ describe('instagram nodes', function() {
                    
                 })
                 .end(function(err, res) {
-                    if (err) return done(err);
+                    if (err) {
+                    	return done(err);
+                    }
                     done();
                 });
             });
@@ -107,7 +109,9 @@ describe('instagram nodes', function() {
                 helper.request()
                 .get('/instagram-credentials/auth')
                 .end(function(err, res) {
-                    if (err) return done(err);
+                    if (err) {
+                    	return done(err);
+                    }
                     res.text.should.equal("ERROR: Received query from UI without the needed credentials");
                     done();
                 });
@@ -115,7 +119,7 @@ describe('instagram nodes', function() {
         });
         
         if (nock) { // featues requiring HTTP communication/mocking // TODO check if all tests require nock here
-            
+        	/*jshint -W082 */
             function doOauthDance(done, matchCsrfToken, return200, serveUserName, serveAccessToken) {
                 var csrfToken; // required to get and process/pass on the token, otherwise OAuth fails
                 
@@ -180,7 +184,9 @@ describe('instagram nodes', function() {
                        
                     })
                     .end(function(err, res) {
-                        if (err) return done(err);
+                        if (err) {
+                        	return done(err);
+                        }
                         // now call the callback URI as if Instagram called it
                         if(matchCsrfToken === true) {
                             if(return200 === true && serveUserName === true && serveAccessToken === true) {
@@ -194,7 +200,9 @@ describe('instagram nodes', function() {
                                     }
                                 })
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     // now call the callback URI as if Instagram called it
                                     done();
                                 });  
@@ -202,7 +210,9 @@ describe('instagram nodes', function() {
                                 helper.request()
                                 .get('/instagram-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.equal("Error! Instagram node has failed to fetch a valid access token.");
                                     done();
                                 }); 
@@ -211,7 +221,9 @@ describe('instagram nodes', function() {
                                 helper.request()
                                 .get('/instagram-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.equal("Error! Instagram node has failed to fetch the username.");
                                     done();
                                 }); 
@@ -219,7 +231,9 @@ describe('instagram nodes', function() {
                                 helper.request()
                                 .get('/instagram-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.equal("Instagram replied with the unexpected HTTP status code of 404\nDetails:\nNo tokens found, sorry!");
                                     done();
                                 }); 
@@ -228,7 +242,9 @@ describe('instagram nodes', function() {
                             helper.request()
                             .get('/instagram-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                             .end(function(err, res) {
-                                if (err) return done(err);
+                                if (err) {
+                                	return done(err);
+                                }
                                 res.text.should.equal("CSRF token mismatch, possible cross-site request forgery attempt.");
                                 done();
                             });   
@@ -427,7 +443,7 @@ describe('instagram nodes', function() {
                 });
                 
             });
-            
+            /*jshint -W082 */
             function fetchUploadedPhotos(done, workingFirstRequest, workingSubsequentRequest) {
             // need to fake the HTTP requests of the init sequence, then straight away the sequence of getting a second photo 
             var photoURI = 'http://mytesturl.com/aPhotoStandard.jpg';

--- a/test/jawboneup/jawboneup_spec.js
+++ b/test/jawboneup/jawboneup_spec.js
@@ -61,13 +61,17 @@ describe('jawboneup nodes', function() {
                                     .get('/jawboneup-credentials/auth?id=n4&callback=http://localhost:1880:/jawboneup-credentials&clientid=abcdefg&appsecret=mnopqrs&response_type=code')
                                     .expect(302)
                                     .end(function(err, res) {
-                                        if (err) return done(err);
+                                        if (err) {
+                                        	return done(err);
+                                        }
                                         var state = res.text.split("state=n4%253A");
                                         helper.request()
                                             .get('/jawboneup-credentials/auth/callback?code=123456&state=n4:'+state[1])
                                             .expect(200)
                                             .end(function(err, res) {
-                                                if (err) return done(err);
+                                                if (err) {
+                                                	return done(err);
+                                                }
                                                 helper.credentials.get("n4")
                                                     .should.have.property('displayname',
                                                                           'John Smith');
@@ -105,13 +109,17 @@ describe('jawboneup nodes', function() {
                             .get('/jawboneup-credentials/auth?id=n4&callback=http://localhost:1880:/jawboneup-credentials&clientid=abcdefg&appsecret=mnopqrs&response_type=code')
                             .expect(302)
                             .end(function(err, res) {
-                                if (err) return done(err);
+                                if (err) {
+                                	return done(err);
+                                }
                               var state = res.text.split("state=n4%253A");
                               helper.request()
                                   .get('/jawboneup-credentials/auth/callback?code=123456&state=n4:'+state[1])
                                   .expect(200)
                                   .end(function(err, res) {
-                                      if (err) return done(err);
+                                      if (err) {
+                                    	  return done(err);
+                                      }
                                       res.text.should.containEql('Oh no');
                                       done();
                                   });
@@ -136,13 +144,17 @@ describe('jawboneup nodes', function() {
                                     .get('/jawboneup-credentials/auth?id=n4&callback=http://localhost:1880:/jawboneup-credentials&clientid=abcdefg&appsecret=mnopqrs&response_type=code')
                                     .expect(302)
                                     .end(function(err, res) {
-                                        if (err) return done(err);
+                                        if (err) {
+                                        	return done(err);
+                                        }
                                         var state = res.text.split("state=n4%253A");
                                         helper.request()
                                             .get('/jawboneup-credentials/auth/callback?code=123456&state=n4:'+state[1])
                                             .expect(200)
                                             .end(function(err, res) {
-                                                if (err) return done(err);
+                                                if (err) {
+                                                	return done(err);
+                                                }
                                                 res.text.should.containEql('Http return code');
                                                 done();
                                             });
@@ -165,12 +177,16 @@ describe('jawboneup nodes', function() {
                                 .get('/jawboneup-credentials/auth?id=n4&clientid=abcdefg&appsecret=mnopqrs&response_type=code&callback=http://localhost:1880:/jawboneup-credentials')
                                 .expect(302)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     helper.request()
                                         .get('/jawboneup-credentials/auth/callback?code=123456&state=n4:13579')
                                         .expect(401)
                                         .end(function(err, res) {
-                                            if (err) return done(err);
+                                            if (err) {
+                                            	return done(err);
+                                            }
                                             res.text.should.containEql('CSRF token mismatch, possible cross-site request forgery attempt');
                                             done();
                                         });
@@ -419,7 +435,7 @@ describe('jawboneup nodes', function() {
                               n1.send({payload:"nothing", foo:"bar", starttime:"1417694436"});
                               n3.on('input', function(msg){
                                   msg.should.have.property('foo', "bar");
-                                  msg.payload.should.be.an.instanceOf(Array).and.have.lengthOf(1);;
+                                  msg.payload.should.be.an.instanceOf(Array).and.have.lengthOf(1);
                                   msg.payload[0].should.have.property('title', "Run");
                                   done();
                               });

--- a/test/openweathermap/weather_spec.js
+++ b/test/openweathermap/weather_spec.js
@@ -39,7 +39,7 @@ describe('weather nodes', function() {
         locationdata.should.have.property("lat", 51.51);
         locationdata.should.have.property("city", "London");
         locationdata.should.have.property("country", "GB");
-    }
+    };
 
     beforeEach(function(done) {
         if(nock){

--- a/test/pinboard/pinboard_spec.js
+++ b/test/pinboard/pinboard_spec.js
@@ -60,7 +60,7 @@ describe('pinboard nodes', function() {
                           }
                       },200);
                   });
-        })
+        });
         
         it(' logs a warning if msg.title is not set', function(done) {
             helper.load(pinboardNode, 
@@ -93,6 +93,6 @@ describe('pinboard nodes', function() {
                           }
                       },200);
                   });
-        })
+        });
     });
 });

--- a/test/strava/strava_spec.js
+++ b/test/strava/strava_spec.js
@@ -75,7 +75,9 @@ describe('Strava node', function() {
                    
                 })
                 .end(function(err, res) {
-                    if (err) return done(err);
+                    if (err) {
+                    	return done(err);
+                    }
                     done();
                 });
             });
@@ -96,7 +98,9 @@ describe('Strava node', function() {
                 helper.request()
                 .get('/strava-credentials/auth')
                 .end(function(err, res) {
-                    if (err) return done(err);
+                    if (err) {
+                    	return done(err);
+                    }
                     res.text.should.equal("ERROR: Received query from UI without the needed credentials");
                     done();
                 });
@@ -104,7 +108,7 @@ describe('Strava node', function() {
         });
         
         if (nock) { // featues requiring HTTP communication/mocking
-            
+        	/*jshint -W082 */
             function doOauthDance(done, matchCsrfToken, return200, serveUserName, serveAccessToken) {
                 var csrfToken; // required to get and process/pass on the token, otherwise OAuth fails
                 
@@ -122,15 +126,15 @@ describe('Strava node', function() {
                 if(return200 === true && serveUserName === true && serveAccessToken === true) {
                     scope = nock('https://www.strava.com')
                     .post('/oauth/token', "client_id=" + clientID + "&client_secret=" + clientSecret + "&code=" + sessionCode)
-                    .reply(200, {"access_token":accessToken,"athlete":{"firstname":"John","lastname": "Smith"}})
+                    .reply(200, {"access_token":accessToken,"athlete":{"firstname":"John","lastname": "Smith"}});
                 } else if(return200 === true && serveUserName === true && serveAccessToken === false) {
                     scope = nock('https://www.strava.com')
                     .post('/oauth/token', "client_id=" + clientID + "&client_secret=" + clientSecret + "&code=" + sessionCode)
-                    .reply(200, {"athlete":{"firstname":"John","lastname": "Smith"}})
+                    .reply(200, {"athlete":{"firstname":"John","lastname": "Smith"}});
                 } else if(return200 === true && serveUserName === false){
                     scope = nock('https://www.strava.com')
                     .post('/oauth/token', "client_id=" + clientID + "&client_secret=" + clientSecret + "&code=" + sessionCode)
-                    .reply(200, {"access_token":accessToken})
+                    .reply(200, {"access_token":accessToken});
                 } else {
                     scope = nock('https://www.strava.com')
                     .post('/oauth/token', "client_id=" + clientID + "&client_secret=" + clientSecret + "&code=" + sessionCode)
@@ -162,7 +166,9 @@ describe('Strava node', function() {
                        
                     })
                     .end(function(err, res) {
-                        if (err) return done(err);
+                        if (err) {
+                        	return done(err);
+                        }
                         // now call the callback URI as if Strava called it
                         if(matchCsrfToken === true) {
                             if(return200 === true && serveUserName === true && serveAccessToken === true) {
@@ -176,7 +182,9 @@ describe('Strava node', function() {
                                     }
                                 })
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     // now call the callback URI as if Strava called it
                                     done();
                                 });  
@@ -184,7 +192,9 @@ describe('Strava node', function() {
                                 helper.request()
                                 .get('/strava-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.equal("Error! Strava node has failed to fetch a valid access token.");
                                     done();
                                 }); 
@@ -193,7 +203,9 @@ describe('Strava node', function() {
                                 helper.request()
                                 .get('/strava-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.equal("Error! Strava node has failed to fetch the authenticated user\'s name.");
                                     done();
                                 }); 
@@ -201,7 +213,9 @@ describe('Strava node', function() {
                                 helper.request()
                                 .get('/strava-credentials/auth/callback?code=' + sessionCode + '&state=n2:' + csrfToken)
                                 .end(function(err, res) {
-                                    if (err) return done(err);
+                                    if (err) {
+                                    	return done(err);
+                                    }
                                     res.text.should.equal("Strava replied with the unexpected HTTP status code of 404");
                                     done();
                                 }); 
@@ -210,7 +224,9 @@ describe('Strava node', function() {
                             helper.request()
                             .get('/strava-credentials/auth/callback?state=n2:' + csrfToken)
                             .end(function(err, res) {
-                                if (err) return done(err);
+                                if (err) {
+                                	return done(err);
+                                }
                                 res.text.should.equal("CSRF token mismatch, possible cross-site request forgery attempt.");
                                 done();
                             });   

--- a/test/tfl/tfl-bus_spec.js
+++ b/test/tfl/tfl-bus_spec.js
@@ -59,7 +59,9 @@ describe('TfL Bus Node', function() {
                     }
                 })
                 .end(function(err, res) {
-                    if (err) return done(err);
+                    if (err) {
+                    	return done(err);
+                    }
                     done();
                 });
             });
@@ -83,7 +85,9 @@ describe('TfL Bus Node', function() {
                     }
                 })
                 .end(function(err, res) {
-                    if (err) return done(err);
+                    if (err) {
+                    	return done(err);
+                    }
                     done();
                 });
             });

--- a/tfl/tfl-bus.js
+++ b/tfl/tfl-bus.js
@@ -106,7 +106,7 @@ module.exports = function(RED) {
         node.radius = n.radius;
 
         if(!node.stopCode1 || !node.lineID || node.stopCode1 === "unset" || node.lineID === "unset") {
-            node.error("No bus stops or bus line numbers have been configured.",msg);
+            node.error("No bus stops or bus line numbers have been configured.");
             return;
         }
 

--- a/tfl/tfl-underground.js
+++ b/tfl/tfl-underground.js
@@ -92,4 +92,4 @@ module.exports = function(RED) {
     
     RED.nodes.registerType("tfl underground", TFLUndergroundQueryNode); 
     
-}
+};

--- a/weatherunderground/wunder.js
+++ b/weatherunderground/wunder.js
@@ -85,7 +85,7 @@ module.exports = function(RED) {
                 msg.payload.forecast = loc.city+" : "+fcast.title+" : "+ fcast.fcttext_metric;
                 callback(null);
             }
-        }
+        };
     }
 
     function WunderInputNode(n) {


### PR DESCRIPTION
Similar to changes made in 606 for node-red project.
Ignore Eclipse created files.
Resolve some Eclipse JSHint warnings for curly brackets, missing commas, dead code in tests (used it.skip), added JSHint ignore for inner functions and fixed not using new for objects.
