### PR TITLE
forecastio: msg.time ignored if its a string

### DIFF
--- a/forecast/forecastio.js
+++ b/forecast/forecastio.js
@@ -201,8 +201,9 @@ module.exports = function(RED) {
                     date = msg.time.toISOString().substring(0,10);
                     time = msg.time.toISOString().substring(11,16);
                 } else if (typeof(msg.time === "string") && !isNaN(parseInt(msg.time))) {
-                    date = (new Date(msg.time)).toISOString().substring(0,10);
-                    time = (new Date(msg.time)).toISOString().substring(11,16);
+                    var epoch = new Date(parseInt(msg.time)).toISOString();
+                    date = epoch.substring(0,10);
+                    time = epoch.substring(11,16);
                 }
             }
             //else if (n.mode === "message" && msg.payload && typeof(msg.payload === "string") && !isNaN(parseInt(msg.payload)) ) {

--- a/forecast/forecastio.js
+++ b/forecast/forecastio.js
@@ -201,9 +201,9 @@ module.exports = function(RED) {
                     date = msg.time.toISOString().substring(0,10);
                     time = msg.time.toISOString().substring(11,16);
                 } else if (typeof(msg.time === "string") && !isNaN(parseInt(msg.time))) {
-                    var epoch = new Date(parseInt(msg.time)).toISOString();
-                    date = epoch.substring(0,10);
-                    time = epoch.substring(11,16);
+                    var epoch = new Date(parseInt(msg.time));
+                    date = epoch.toISOString().substring(0,10);
+                    time = epoch.toISOString().substring(11,16);
                 }
             }
             //else if (n.mode === "message" && msg.payload && typeof(msg.payload === "string") && !isNaN(parseInt(msg.payload)) ) {


### PR DESCRIPTION
```js
> new Date("1459061800120")
Invalid Date
> new Date(parseInt("1459061800120"))
Sun Mar 27 2016 09:56:40 GMT+0300 (EEST)
```