### PR TITLE
Propose changing polling to obtain only latest changes

### DIFF
--- a/dropbox/dropbox.js
+++ b/dropbox/dropbox.js
@@ -61,10 +61,11 @@ module.exports = function(RED) {
                     return;
                 }
                 node.status({});
-                if (!node.state) {
+                if (!node.state) { // when executed for the first time only save cursor
                     node.state = data.cursor();
                 }
-                else {
+                else { 
+                    node.state = data.cursor(); // reset cursor to get only changes since last poll
                     var changes = data.changes;
                     for (var i = 0; i < changes.length; i++) {
                         var change = changes[i];

--- a/dropbox/dropbox.js
+++ b/dropbox/dropbox.js
@@ -35,7 +35,7 @@ module.exports = function(RED) {
     function DropboxInNode(n) {
         RED.nodes.createNode(this,n);
         this.filepattern = n.filepattern || "";
-        this.checkInterval = n.checkInterval || 600000;
+        this.checkInterval = n.checkInterval || 60000;
         this.dropboxConfig = RED.nodes.getNode(n.dropbox);
         var credentials = this.dropboxConfig ? this.dropboxConfig.credentials : {};
         if (!credentials.appkey || !credentials.appsecret ||


### PR DESCRIPTION
In master, the dropbox poll pulled all changes since node-red flow was started. IMO, this is not counterintuitive - i.e. I expected to get latest changes (only changes since the last poll). 

Modified so that 
- poll is done 1 x /min
- cursor is resetted after every poll => only new changes are obtained