### PR TITLE
msg.location.lon and lat descriptions were swapped

### DIFF
--- a/forecast/forecastio.html
+++ b/forecast/forecastio.html
@@ -184,8 +184,8 @@
     </ul>
     <p>The node also sets:</p>
     <ul>
-        <li><code>msg.location.lat</code> - the longitude of the location from which the data was sourced.</li>
-        <li><code>msg.location.lon</code> - the latitude of the location from which the data was sourced.</li>
+        <li><code>msg.location.lon</code> - the longitude of the location from which the data was sourced.</li>
+        <li><code>msg.location.lat</code> - the latitude of the location from which the data was sourced.</li>
     </ul>
     <p>Finally, the node sets: <code>msg.title</code>, <code>msg.description</code> and</p>
     <ul>


### PR DESCRIPTION
Aligns the description of the node with the code.