### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dropbox":"^0.10.3",
         "minimatch": "^1.0.0",
         "oauth":"~0.9.11",
-        "request":"~2.40.0",
+        "request":"~2.74.0",
         "instagram-node":"0.5.1",
         "clone": "0.1.11",
         "xml2js":"0.4.*",


### PR DESCRIPTION
node-red-web-nodes currently has a 3 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes vulnerable dependencies,[ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/node-red/node-red-web-nodes) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `minimatch` dependency as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
