### PR TITLE
Prevents node from crashing node-red when receiving an unexpected res…

### DIFF
--- a/weatherunderground/wunder.js
+++ b/weatherunderground/wunder.js
@@ -84,7 +84,11 @@ module.exports = function(RED) {
                     msg.description = RED._("wunder.message.description", {lat: msg.location.lat, lon: msg.location.lon});
                     msg.payload.description = (RED._("wunder.message.payload", {city: msg.location.city, lat: msg.location.lat, lon: msg.location.lon, weather: cur.weather}));
                     var fcast = res.forecast.txt_forecast.forecastday[0];
-                    msg.payload.forecast = loc.city+" : "+fcast.title+" : "+ fcast.fcttext_metric;
+                    if(typeof fcast !== 'undefined') {
+                        msg.payload.forecast = loc.city+" : "+fcast.title+" : "+ fcast.fcttext_metric;
+                    } else {
+						msg.payload.forecast="";
+					}
                     callback(null);
                 }
                 else {


### PR DESCRIPTION
…ponse from the WU site

I've been getting quite a few of these:

 28 Oct 05:06:34 - [red] Uncaught Exception:
 28 Oct 05:06:34 - TypeError: Cannot read property 'title' of undefined
 at handleResponse (/home/pi/.node-red/node_modules/node-red-node-weather-underground/wunder.js:87:64)
 at null.<anonymous> (/home/pi/.node-red/node_modules/node-red-node-weather-underground/wunder.js:51:24)
 at Request._callback (/home/pi/.node-red/node_modules/node-red-node-weather-underground/node_modules/wundergroundnode/lib/wundergroundnode.js:137:26)
 at Request.self.callback (/home/pi/.node-red/node_modules/node-red-node-weather-underground/node_modules/wundergroundnode/node_modules/request/request.js:187:22)
 at emitTwo (events.js:87:13)
 at Request.emit (events.js:172:7)
 at Request.<anonymous> (/home/pi/.node-red/node_modules/node-red-node-weather-underground/node_modules/wundergroundnode/node_modules/request/request.js:1044:10)
 at emitOne (events.js:77:13)
 at Request.emit (events.js:169:7) at IncomingMessage.<anonymous> (/home/pi/.node-red/node_modules/node-red-node-weather-underground/node_modules/wundergroundnode/node_modules/request/request.js:965:12)

This commit prevents it from happening again