### PR TITLE
Update package.json to use newer wundergroundnode(0.11.0)

### DIFF
--- a/weatherunderground/package.json
+++ b/weatherunderground/package.json
@@ -3,7 +3,7 @@
     "version"       : "0.1.7",
     "description"   : "A Node-RED node that gets the weather report and forecast from The Weather Underground",
     "dependencies"  : {
-        "wundergroundnode":"0.9.*"
+        "wundergroundnode":"0.11.*"
     },
     "repository" : {
         "type":"git",


### PR DESCRIPTION
Sometimes node-red crashes in wundergroundnode when using node-red-node-weather-underground. Newer version of wundergroundnode should help.