### PR TITLE
Fix extracting the end date of an event

### DIFF
--- a/google/calendar.js
+++ b/google/calendar.js
@@ -513,7 +513,7 @@ module.exports = function(RED) {
         }
         if (ev[type] && ev[type].dateTime) {
             return new Date(ev[type].dateTime);
-        } else if (ev.start && ev.start.date) {
+        } else if (ev.start && ev.start.date || ev.end && ev.end.date) {
             return new Date(ev[type].date);
         } else {
             return null;


### PR DESCRIPTION
Possible fix for issue https://github.com/node-red/node-red-web-nodes/issues/187.

Extract the end date properly when an all day event is returned from Google Calendar API.