### PR TITLE
Remove Node.js v7 from travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ addons:
     packages:
     - g++-4.8
     - gcc-4.8
-matrix:
-  allow_failures:
-  - node_js: "7"
 node_js:
   - "8"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
   - node_js: "7"
 node_js:
   - "8"
-  - "7"
   - "6"
   - "4"
 before_script:


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I removed Node.js v7 from .travis.yml because it isn't supported and it's removed from other repositories (node-red and node-red-nodes).

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality