### PR TITLE
fix(forecastio): specified input date is not considered

### DIFF
--- a/forecast/forecastio.js
+++ b/forecast/forecastio.js
@@ -208,7 +208,7 @@ module.exports = function(RED) {
                     time = epoch.toISOString().substring(11,16);
                 }
                 else {
-                    if (msg.time.toISOstring) {
+                    if (msg.time.toISOString) {
                         date = msg.time.toISOString().substring(0,10);
                         time = msg.time.toISOString().substring(11,16);
                     }


### PR DESCRIPTION
Fixes a small typing error which prevents using a Javascript date as node input.