### PR TITLE
Calendar: Handle multiple events

### DIFF
--- a/google/calendar.html
+++ b/google/calendar.html
@@ -145,6 +145,10 @@
         <input type="text" id="node-input-name">
     </div>
     <div class="form-row">
+        <label for="node-input-count"><i class="fa fa-hashtag"></i> <span data-i18n="[title]calendar.helptext.count;calendar.label.count"></span></label>
+        <input type="number" min="1" max="10" id="node-input-count" style="display: inline-block; width: auto;">
+    </div>
+    <div class="form-row">
         <input type="checkbox" id="node-input-ongoing" placeholder="" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-ongoing" style="width: 70%;">Include ongoing events</label>
     </div>
@@ -156,6 +160,7 @@
     <ul>
       <li><b>payload</b> - a text search string used to select relevant events</li>
       <li><b>calendar</b> - the calendar to retrieve the event from (optional, defaults to the node calendar property or the users primary calendar)</li>
+      <li><b>count</b> - the number of events to retrieve (Accepted values are [1-10]. If larger than 1, an array will be returned)</li>
     </ul>
   </p>
   <p>The message sent from the node will have properties:
@@ -188,7 +193,10 @@
             google: {type:"google-credentials",required:true},
             name: {value:""},
             calendar: {value:""},
-            ongoing: {value: false}
+            ongoing: {value: false},
+            count: {value: 1, validate: function(n) {
+                return +n >= 1 && +n <= 10;
+            }}
         },
         inputs:1,
         outputs:1,

--- a/google/calendar.js
+++ b/google/calendar.js
@@ -141,6 +141,10 @@ module.exports = function(RED) {
         this.google = RED.nodes.getNode(n.google);
         this.calendar = n.calendar || 'primary';
         this.ongoing = n.ongoing || false;
+        this.count = +n.count;
+        if (!Number.isInteger(this.count)) { this.count = 1; }
+        else if (this.count < 1) { this.count = 1; }
+        else if (this.count > 10) { this.count = 10; }
 
         if (!this.google || !this.google.credentials.accessToken) {
             this.warn(RED._("calendar.warn.no-credentials"));
@@ -166,17 +170,22 @@ module.exports = function(RED) {
                     node.status({fill:"red",shape:"ring",text:"calendar.status.invalid-calendar"});
                     return;
                 }
-                nextStartingEvent(node, cal, msg, function(err, ev) {
+                nextStartingEvents(node, cal, msg, function(err, ev) {
                     if (err) {
                         node.error(RED._("calendar.error.error", {error:err.toString()}),msg);
                         node.status({fill:"red",shape:"ring",text:"calendar.status.failed"});
                         return;
                     }
-                    if (!ev) {
+                    if (!ev[0]) {
                         node.error(RED._("calendar.error.no-event"),msg);
                         node.status({fill:"red",shape:"ring",text:"calendar.status.no-event"});
                     } else {
-                        sendEvent(node, ev, msg);
+                        // If count is 1, then don't send as an array
+                        if (node.count === 1) {
+                            sendEvent(node, ev[0], msg);
+                        } else {
+                            sendEvents(node, ev.slice(0, node.count), msg);
+                        }
                         node.status({});
                     }
                 });
@@ -227,7 +236,7 @@ module.exports = function(RED) {
         });
     }
 
-    function nextStartingEvent(node, cal, msg, after, cb) {
+    function nextStartingEvents(node, cal, msg, after, cb) {
         if (typeof after === 'function') {
             cb = after;
             after = new Date();
@@ -237,7 +246,7 @@ module.exports = function(RED) {
             url: 'https://www.googleapis.com/calendar/v3/calendars/'+cal.id+'/events'
         };
         request.qs = {
-            maxResults: 10,
+            maxResults: node.count || 10,
             orderBy: 'startTime',
             singleEvents: true,
             showDeleted: false,
@@ -246,34 +255,42 @@ module.exports = function(RED) {
         if (msg.payload) {
             request.qs.q = RED.util.ensureString(msg.payload);
         }
+        var events = [];
         var handle_response = function(err, data) {
             if (err) {
                 cb(RED._("calendar.error.error", {error:err.toString()}), null);
             } else if (data.error) {
                 cb(RED._("calendar.error.error-details", {code:data.error.code, message:JSON.stringify(data.error.message)}), null);
             } else {
-                var ev;
                 /* 0 - 10 events ending after now ordered by startTime
                  * so we find the first that starts after now to
                  * give us the "next" event
                  */
                 for (var i = 0; i<data.items.length; i++) {
-                    ev = data.items[i];
+                    var ev = data.items[i];
                     var start = getEventDate(ev);
                     if (node.ongoing || (start && start.getTime() > after.getTime())) {
-                        break;
+                        events.push(ev);
                     }
-                    ev = undefined;
                 }
-                if (!ev && data.hasOwnProperty('nextPageToken')) {
+                // If we don't yet have node.count events, fetch next page
+                if (events.length < (node.count || 10) && data.hasOwnProperty('nextPageToken')) {
                     request.qs.pageToken = data.nextPageToken;
                     node.google.request(request, handle_response);
                 } else {
-                    cb(null, ev);
+                    cb(null, events);
                 }
             }
         };
         node.google.request(request, handle_response);
+    }
+
+    function nextStartingEvent(node, cal, msg, after, cb) {
+        // gets the first item of the events array
+        function _cb(err, events) {
+            cb(err, events[0]);
+        }
+        nextStartingEvents(node, cal, msg, after, _cb);
     }
 
     function nextEndingEvent(node, cal, msg, after, cb) {
@@ -450,17 +467,59 @@ module.exports = function(RED) {
         });
     }
 
-    function sendEvent(node, ev, msg) {
+    function prepareEventData(ev) {
+        var data = {};
+        if (ev.summary) {
+            data.title = ev.summary;
+        }
+        if (ev.description) {
+            data.description = ev.description;
+        }
+        if (ev.location) {
+            data.location = {
+                description: ev.location
+            };
+        }
+        var start = getEventDate(ev);
+        if (start) {
+            data.start = start;
+        }
+        if (ev.start && ev.start.date) {
+            data.allDayEvent = true;
+        }
+        var end = getEventDate(ev, 'end');
+        if (end) {
+            data.end = end;
+        }
+        if (ev.creator) {
+            data.creator = {
+                name: ev.creator.displayName,
+                email: ev.creator.email,
+            };
+        }
+        if (ev.attendees) {
+            data.attendees = [];
+            ev.attendees.forEach(function (a) {
+                data.attendees.push({
+                    name: a.displayName,
+                    email: a.email
+                });
+            });
+        }
+        return data;
+    }
+
+    function prepareEventMessage(ev, msg) {
         if (typeof msg === 'undefined') {
             msg = {};
         }
         delete msg.error;
-        var payload = msg.payload = {};
-        if (ev.summary) {
-            payload.title = msg.title = ev.summary;
+        var payload = msg.payload = prepareEventData(ev);
+        if (payload.title) {
+            msg.title = payload.title;
         }
-        if (ev.description) {
-            payload.description = msg.description = ev.description;
+        if (payload.description) {
+            msg.description = payload.description;
         } else {
             delete msg.description;
         }
@@ -472,39 +531,20 @@ module.exports = function(RED) {
              * msg.location.{lat,lon} then both copies
              * will be updated.
              */
-            payload.location = msg.location = {
-                description: ev.location
-            };
+            msg.location = payload.location;
         } else {
             delete msg.location;
         }
-        var start = getEventDate(ev);
-        if (start) {
-            payload.start = start;
-        }
-        if (ev.start && ev.start.date) {
-            payload.allDayEvent = true;
-        }
-        var end = getEventDate(ev, 'end');
-        if (end) {
-            payload.end = end;
-        }
-        if (ev.creator) {
-            payload.creator = {
-                name: ev.creator.displayName,
-                email: ev.creator.email,
-            };
-        }
-        if (ev.attendees) {
-            payload.attendees = [];
-            ev.attendees.forEach(function (a) {
-                payload.attendees.push({
-                    name: a.displayName,
-                    email: a.email
-                });
-            });
-        }
         msg.data = ev;
+    }
+
+    function sendEvent(node, ev, msg) {
+        prepareEventMessage(ev, msg);
+        node.send(msg);
+    }
+
+    function sendEvents(node, ev, msg) {
+        msg.payload = ev.map(prepareEventData);
         node.send(msg);
     }
 

--- a/google/locales/en-US/calendar.json
+++ b/google/locales/en-US/calendar.json
@@ -18,7 +18,8 @@
             "days": "days",
             "before": "before",
             "start": "start",
-            "name": "Name"
+            "name": "Name",
+            "count": "Events"
         },
         "status": {
             "querying": "querying",
@@ -37,6 +38,9 @@
             "no-event": "Error: no event found",
             "fetch-failed": "failed to fetch calendar list: __message__",
             "error-details": "Error __code__: __message__"
+        },
+        "helptext": {
+            "count": "Number of events to return [1-10]"
         }
     }
 }


### PR DESCRIPTION
## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

This Pull Requests adds a new property to the "google calendar" node: `count`.
It defaults to `1`, and with this value, the behavior is unchanged. It returns the exact same payload as it currently does, so it doesn't break any current flows.

If `count` is `> 1`, it now returns an array of events (as a single message).
I set it to have a maximum value of `10`, because the code was already using this number to fetch events. I thought it best to not change too much of the code.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
  I did [bring this up](https://node-red.slack.com/archives/C03M2TAQ8/p1597785334093600) on #general on Slack. But I'm also issuing this PR early so it can be easier to follow on the discussion on Slack.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
