### PR TITLE
fixed google calendar i18n support

### DIFF
--- a/google/calendar.html
+++ b/google/calendar.html
@@ -46,7 +46,7 @@
             <option value="hours" data-i18n="calendar.label.hours"></option>
             <option value="days" data-i18n="calendar.label.days"></option>
         </select>
-        <span id="node-input-type"><span data-i18n="calendar.label.before"></span></span> <span data-i18n="calendar.label.the"></span> <span id="node-input-from"><span data-i18n="calendar.label.start"></span></span> <span data-i18n="calendar.label.each-event"></span>
+        <span id="node-input-type"><span data-i18n="calendar.label.option_before"></span></span> <span data-i18n="calendar.label.the"></span> <span id="node-input-from"><span data-i18n="calendar.label.option_start"></span></span> <span data-i18n="calendar.label.each-event"></span>
     </div>
 
     <div class="form-row">
@@ -76,6 +76,10 @@
         },
         oneditprepare: function() {
             var type = this.offsetType || "at";
+            var type_before = this._("calendar.label.option_before");
+            var type_after = this._("calendar.label.option_after");
+            var from_start = this._("calendar.label.option_start");
+            var from_end = this._("calendar.label.option_end");
             $("#node-input-offsetType option").filter(function() {
                 return $(this).val() == type;
             }).attr('selected', true);
@@ -95,8 +99,16 @@
                 if (type === "at") {
                     $("#node-row-offset").hide();
                 } else {
-                    $("#node-input-type").html(type);
-                    $("#node-input-from").html(from);
+                    if (type === "before") {
+                        $("#node-input-type").html(type_before);
+                    } else if (type === "after") {
+                        $("#node-input-type").html(type_after);
+                    }
+                    if (from === "start") {
+                        $("#node-input-from").html(from_start);
+                    } else if (from === "end") {
+                        $("#node-input-from").html(from_end);
+                    }
                     $("#node-row-offset").show();
                 }
              };

--- a/google/locales/en-US/calendar.json
+++ b/google/locales/en-US/calendar.json
@@ -16,8 +16,6 @@
             "minutes": "minutes",
             "hours": "hours",
             "days": "days",
-            "before": "before",
-            "start": "start",
             "name": "Name",
             "count": "Events"
         },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
this two dynamic words are forgotten to support i18n (see picture)
and calendar.label.before and calendar.label.start are double/obsolete

![grafik](https://user-images.githubusercontent.com/74769863/111030469-b7992480-8402-11eb-9b5d-0323fcdc5a0f.png)

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
