### PR TITLE
Fix issue to output same messages from amazon s3 in node

### DIFF
--- a/aws/aws.js
+++ b/aws/aws.js
@@ -86,20 +86,22 @@ module.exports = function(RED) {
                         if (seen[file]) {
                             delete seen[file];
                         } else {
-                            msg.payload = file;
-                            msg.file = file.substring(file.lastIndexOf('/')+1);
-                            msg.event = 'add';
-                            msg.data = newContents[i];
-                            node.send(msg);
+                            var newMessage = RED.util.cloneMessage(msg);
+                            newMessage.payload = file;
+                            newMessage.file = file.substring(file.lastIndexOf('/')+1);
+                            newMessage.event = 'add';
+                            newMessage.data = newContents[i];
+                            node.send(newMessage);
                         }
                     }
                     for (var f in seen) {
                         if (seen.hasOwnProperty(f)) {
-                            msg.payload = f;
-                            msg.file = f.substring(f.lastIndexOf('/')+1);
-                            msg.event = 'delete';
-                            // msg.data intentionally null
-                            node.send(msg);
+                            var newMessage = RED.util.cloneMessage(msg);
+                            newMessage.payload = f;
+                            newMessage.file = f.substring(f.lastIndexOf('/')+1);
+                            newMessage.event = 'delete';
+                            // newMessage.data intentionally null
+                            node.send(newMessage);
                         }
                     }
                     node.state = newContents.map(function (e) {return e.Key;});


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The current Amazon S3 node output the same messages after uploading multiple files to S3 bucket. This issue occurs due to no message clone handling in the node. Therefore, I modified the code to use message clone.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality