### PR TITLE
Use refresh tokens for Dropbox

### DIFF
--- a/dropbox/dropbox.html
+++ b/dropbox/dropbox.html
@@ -16,17 +16,32 @@
 
 <script type="text/x-red" data-template-name="dropbox-config">
     <div class="form-row">
-        <label for="node-config-input-accesstoken"><span data-i18n="dropbox.label.accesstoken"></span></label>
-        <input class="input-append-left" type="password" id="node-config-input-accesstoken" >
+        <label for="node-config-input-clientid"><span data-i18n="dropbox.label.appkey"></span></label>
+        <input class="input-append-left" type="password" id="node-config-input-clientid" >
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-refreshtoken"><span data-i18n="dropbox.label.refreshtoken"></span></label>
+        <input class="input-append-left" type="password" id="node-config-input-refreshtoken" >
     </div>
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="dropbox.label.name"></span></label>
         <input type="text" id="node-config-input-name" data-i18n="[placeholder]dropbox.placeholder.name">
     </div>
     <div class="form-tips">
-        <span data-i18n="[html]dropbox.tip.cred1"></span>
-        <span data-i18n="[html]dropbox.tip.cred2"></span>
-        <span data-i18n="[html]dropbox.tip.cred3"></span>
+        <ol>
+            <li><span data-i18n="[html]dropbox.tip.cred1"></span></li>
+            <li><span data-i18n="[html]dropbox.tip.cred2"></span></li>
+            <li><span data-i18n="[html]dropbox.tip.cred3"></span></li>
+            <li><span data-i18n="[html]dropbox.tip.cred4"></span></li>
+            <li><span data-i18n="[html]dropbox.tip.cred5"></span></li>
+            <ul>
+                <li><span data-i18n="[html]dropbox.tip.cred6"></span></li>
+                <li><span data-i18n="[html]dropbox.tip.cred7"></span></li>
+                <li><span data-i18n="[html]dropbox.tip.cred8"></span></li>
+            </ul>
+            <li><span data-i18n="[html]dropbox.tip.cred9"></span></li>
+            <li><span data-i18n="[html]dropbox.tip.cred10"></span></li>
+        </ol>
     </div>
 </script>
 
@@ -38,12 +53,77 @@
             name: {value:""}
         },
         credentials: {
-            accesstoken: {type: "password",required:true},
+            clientid: {type: "password",required:true},
+            refreshtoken: {type: "password",required:true}
         },
         label: function() {
             return this.name||this._("dropbox.label.dropbox"); // TODO: get display_name from account info?
         },
         exportable: false,
+        oneditprepare: function() { 
+            var node = this;
+
+            // Use a (zero) timeout because the anchor id's in the data-i18n texts are not known yet at this moment
+            setTimeout(function() {
+                $.ajax({
+                    url: "dropbox/generate_redirect_url",
+                    type: "GET",
+                    datatype: 'json',
+                    success: function(data) {
+                        node.redirectUrl = data.redirectUrl;
+                        $("#node-dropbox-redirect-url").html("<b><i>" + data.redirectUrl + "</b></i>");
+                    },
+                    error: function(xhr) {
+                        alert(xhr.responseText);
+                    }
+                });
+            
+                $("#node-dropbox-app-link").click(function(e) {
+                    e.preventDefault();
+                    
+                    $.ajax({
+                        url: "dropbox/generate_authentication_url",
+                        type: "GET",
+                        data: { 
+                            nodeId: node.id,
+                            clientid: $("#node-config-input-clientid").val().trim(),
+                            redirectUrl: node.redirectUrl
+                        },
+                        datatype: 'json',
+                        success: function(data) {
+                            var authUrl = data.authUrl;
+                            // Don't use a redirect (http 302) in the 'generate_authentication_url' endpoint, because redirecting this
+                            // ajax call to a remote host (i.e. a non Node-RED host) will result in CORS issues.
+                            // Therefore the endpoint will return simply the url of the Dropbox authentication server, and the url
+                            // will be opened here in a popup window.  Note that the browser settings might to be adjusted to allow popups.
+                            var popup = window.open(authUrl, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
+                            popup.document.title = node._("dropbox.text.auth-flow");
+                        },
+                        error: function(xhr) {
+                            alert(xhr.responseText);
+                        }
+                    });
+                });
+
+                $("#node-dropbox-refresh-access-token").click(function(e) {
+                    e.preventDefault();
+                    $.ajax({
+                        url: "dropbox/refresh_access_token",
+                        type: "GET",
+                        data: { 
+                            nodeId: node.id
+                        },
+                        datatype: 'json',
+                        success: function(data) {
+                            alert(node._("dropbox.text.access-token-refreshed"));
+                        },
+                        error: function(xhr) {
+                            alert(xhr.responseText);
+                        }
+                    });
+                });                
+            }, 0);
+        }
     });
 })();
 </script>

--- a/dropbox/dropbox.html
+++ b/dropbox/dropbox.html
@@ -97,31 +97,13 @@
                             // Therefore the endpoint will return simply the url of the Dropbox authentication server, and the url
                             // will be opened here in a popup window.  Note that the browser settings might to be adjusted to allow popups.
                             var popup = window.open(authUrl, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
-                            popup.document.title = node._("dropbox.text.auth-flow");
+                            popup.document.title = node._("dropbox.title.auth-flow");
                         },
                         error: function(xhr) {
                             alert(xhr.responseText);
                         }
                     });
-                });
-
-                $("#node-dropbox-refresh-access-token").click(function(e) {
-                    e.preventDefault();
-                    $.ajax({
-                        url: "dropbox/refresh_access_token",
-                        type: "GET",
-                        data: { 
-                            nodeId: node.id
-                        },
-                        datatype: 'json',
-                        success: function(data) {
-                            alert(node._("dropbox.text.access-token-refreshed"));
-                        },
-                        error: function(xhr) {
-                            alert(xhr.responseText);
-                        }
-                    });
-                });                
+                });               
             }, 0);
         }
     });

--- a/dropbox/dropbox.js
+++ b/dropbox/dropbox.js
@@ -408,7 +408,7 @@ module.exports = function(RED) {
             // The response contains two tokens (but only the refresh token is relevant for our use case):
             // 1.- A (long-lived) refresh token which will never expire.
             // 2.- A (short-lived) access token which will expire after 4 hours.  Note such tokens start with "sl.".
-            var html = "<html><head><title>" +  RED._("dropbox.text.auth-flow") + "</title></head><body><h1>" + RED._("dropbox.label.refreshtoken") + "</h1>" + response.result.refresh_token + "</body></html>";
+            var html = "<html><head><title>" +  RED._("dropbox.title.auth-flow") + "</title></head><body><h1>" + RED._("dropbox.label.refreshtoken") + "</h1>" + response.result.refresh_token + "</body></html>";
             res.end(html);
             globalDropboxInstance = null;
         })
@@ -416,28 +416,5 @@ module.exports = function(RED) {
             res.writeHead(500);
             res.end(err.message);
         });
-    });
-    
-    RED.httpAdmin.get('/dropbox/refresh_access_token', function(req, res) {
-        var dropboxNode = RED.nodes.getNode(req.query.nodeId);
-        if (!dropboxNode) {
-            res.writeHead(400);
-            res.end(RED._("dropbox.error.node-not-deployed"));
-            return;
-        }
-        
-        var currentRefreshToken = dropboxNode.dropbox.auth.getRefreshToken();
-        
-        if (!currentRefreshToken || currentRefreshToken.trim() === "") {
-            res.writeHead(400);
-            res.end(RED._("dropbox.error.no-refresh-token"));
-            return;
-        }        
-        
-        // Get a new access token, based on the refresh token in the config node (even when the access token hasn't expired yet)
-        dropboxNode.dropbox.auth.refreshAccessToken();
-        
-        res.writeHead(200);
-        res.end();
     });
 };

--- a/dropbox/dropbox.js
+++ b/dropbox/dropbox.js
@@ -41,8 +41,8 @@ module.exports = function(RED) {
 
         var dropboxConfig = RED.nodes.getNode(n.dropbox);
         var credentials = dropboxConfig ? dropboxConfig.credentials : {};
-        if (!credentials.accesstoken) {
-            this.warn(RED._("dropbox.warn.missing-credentials"));
+        if (!credentials.refreshtoken) {
+            this.warn(RED._("dropbox.warn.missing-refresh-token"));
             return;
         }
 
@@ -205,8 +205,8 @@ module.exports = function(RED) {
 
         var dropboxConfig = RED.nodes.getNode(n.dropbox);
         var credentials = dropboxConfig ? dropboxConfig.credentials : {};
-        if (!credentials.accesstoken) {
-            this.warn(RED._("dropbox.warn.missing-credentials"));
+        if (!credentials.refreshtoken) {
+            this.warn(RED._("dropbox.warn.missing-refresh-token"));
             return;
         }
         var node = this;
@@ -258,8 +258,8 @@ module.exports = function(RED) {
 
         var dropboxConfig = RED.nodes.getNode(n.dropbox);
         var credentials = dropboxConfig ? dropboxConfig.credentials : {};
-        if (!credentials.accesstoken) {
-            this.warn(RED._("dropbox.warn.missing-credentials"));
+        if (!credentials.refreshtoken) {
+            this.warn(RED._("dropbox.warn.missing-refresh-token"));
             return;
         }
         var node = this;

--- a/dropbox/dropbox.js
+++ b/dropbox/dropbox.js
@@ -25,12 +25,14 @@ module.exports = function(RED) {
     function DropboxNode(n) {
         RED.nodes.createNode(this,n);
         this.dropbox = new Dropbox({
-            accessToken: this.credentials.accesstoken
+            clientId: this.credentials.clientid,
+            refreshToken: this.credentials.refreshtoken
         });
     }
     RED.nodes.registerType("dropbox-config",DropboxNode,{
         credentials: {
-            accesstoken: { type:"password" },
+            clientid: { type:"password" },
+            refreshtoken: { type:"password" }
         }
     });
 
@@ -323,4 +325,119 @@ module.exports = function(RED) {
         });
     }
     RED.nodes.registerType("dropbox out",DropboxOutNode);
+
+    var globalDropboxInstance = null;
+
+    RED.httpAdmin.get('/dropbox/generate_redirect_url', function(req, res) {
+        // Once the Dropbox authentication server has finished its authentication flow, it will send the results (incl. the refresh token) to our redirect url.
+        // Since the Dropbox instance (= the dropbox client) is executing the redirect, "localhost" will also be a valid host.
+        // Parts of the original will be reused, to make sure all path related settings.js adjustments are used here.
+        var redirectUrl = req.protocol + "://" + req.get('host') + req.originalUrl.replace("generate_redirect_url", "authenticate");
+        res.json({redirectUrl: redirectUrl});
+    });
+
+    RED.httpAdmin.get('/dropbox/generate_authentication_url', function(req, res) {
+        var options = {};
+
+        // When the config node has been deployed previously, it might contain deployed settings which need to be used
+        var dropboxNode = RED.nodes.getNode(req.query.nodeId);
+        if(dropboxNode) {
+            options.clientId = dropboxNode.credentials.clientid;
+        }
+        
+        // The config node's config screen might contain an undeployed clientId, which will override the client id from the deployed config node settings.
+        if (req.query.clientid && req.query.clientid !== "__PWRD__") {
+            options.clientId = req.query.clientid;
+        }
+        
+        if (!options.clientId) {
+            res.writeHead(500);
+            res.end(RED._("dropbox.error.no-app-key"));
+            return;
+        }
+
+        // Pass the redirect uri to our second 'authenticate' endpoint via the session state, because getAccessTokenFromCode needs the redirectUri we have been using here. 
+        var state = JSON.stringify({redirectUri: req.query.redirectUrl});
+
+        try {
+            // Create a new temporary Dropbox instance, because at this moment the config node (and its Dropbox instance) might not have been deployed yet.
+            var tempDropbox = new Dropbox(options);
+
+            // Get the authentication URL of this client app, to start an authentication flow on the Dropbox authentication server.
+            // The 'offline' argument is required to get a (long-lived) refresh token.  Because offline applications will access the API, without
+            // the manual intervention of an end user.  That refresh token can be used afterwards to obtain a new (short-lived) access token.
+            var authUrl = tempDropbox.auth.getAuthenticationUrl(req.query.redirectUrl, state, 'code', 'offline', null, 'none', true)
+            .then(function(authUrl) {
+                // In the next 'authenticate' endpoint, again a Dropbox instance will be needed.  Pass the current dropbox instance to the next endpoint, because
+                // (as a result of the getAuthenticationUrl call) it's 'codeVerifier' property will be filled in.  And that property is needed to call
+                // getAccessTokenFromCode in the next endpoint, to avoid having the user to go throught an entire Authorization Code Flow (with PKCE).
+                // Reusing the Dropbox instance seems more secure, compared to pass the codeVerifier via the session state to the next endpoint.
+                globalDropboxInstance = tempDropbox;
+    
+                // Redirect the request from the Node-RED flow editor to the Dropbox authentication server.
+                // The user should manually confirm (in the Dropbox authentication page) that this client app can be linked to the dropbox account.
+                // This starts the OAuth 2.0 authorization flow. This isn't an API call—it's the web page that lets the user sign in to Dropbox and authorize your app. 
+                // After the user decides whether or not to authorize your app, they will be redirected to the URI specified by redirect_uri.
+                res.json({authUrl: authUrl});
+            })
+            .catch(function(error) {
+                res.writeHead(500);
+                res.end(RED._("dropbox.error.auth-url-failed"));
+                return;
+            })
+        }
+        catch(err) {
+            res.writeHead(500);
+            res.end(err.message);            
+        }
+    });
+
+    // Dropbox will call this endpoint as soon as i authentication flow has ended
+    RED.httpAdmin.get('/dropbox/authenticate', function(req, res) {
+        var accessCode = req.query.code;
+        var state = JSON.parse(req.query.state);
+
+        // Ask Dropbox for an access token (and refresh token), based on the access code that we have received.
+        // Note that redirectUri won't be called again here, but the URL needs to be exactly the same as the one that has been called previously (in getAuthenticationUrl).
+        // Show the refresh token in the popup window, where it can be copied by the user and pasted into the config node's screen.
+        globalDropboxInstance.auth.getAccessTokenFromCode(state.redirectUri, accessCode)
+        .then(function(response) {
+            res.setHeader("Content-Type", "text/html");
+            res.writeHead(200);
+            
+            // The response contains two tokens (but only the refresh token is relevant for our use case):
+            // 1.- A (long-lived) refresh token which will never expire.
+            // 2.- A (short-lived) access token which will expire after 4 hours.  Note such tokens start with "sl.".
+            var html = "<html><head><title>" +  RED._("dropbox.text.auth-flow") + "</title></head><body><h1>" + RED._("dropbox.label.refreshtoken") + "</h1>" + response.result.refresh_token + "</body></html>";
+            res.end(html);
+            globalDropboxInstance = null;
+        })
+        .catch(function(error) {
+            res.writeHead(500);
+            res.end(err.message);
+        });
+    });
+    
+    RED.httpAdmin.get('/dropbox/refresh_access_token', function(req, res) {
+        var dropboxNode = RED.nodes.getNode(req.query.nodeId);
+        if (!dropboxNode) {
+            res.writeHead(400);
+            res.end(RED._("dropbox.error.node-not-deployed"));
+            return;
+        }
+        
+        var currentRefreshToken = dropboxNode.dropbox.auth.getRefreshToken();
+        
+        if (!currentRefreshToken || currentRefreshToken.trim() === "") {
+            res.writeHead(400);
+            res.end(RED._("dropbox.error.no-refresh-token"));
+            return;
+        }        
+        
+        // Get a new access token, based on the refresh token in the config node (even when the access token hasn't expired yet)
+        dropboxNode.dropbox.auth.refreshAccessToken();
+        
+        res.writeHead(200);
+        res.end();
+    });
 };

--- a/dropbox/locales/en-US/dropbox.json
+++ b/dropbox/locales/en-US/dropbox.json
@@ -27,11 +27,10 @@
             "cred7": "Since the refresh token doesn't expire, this step needs to be executed only once.  But if required, it can be repeated afterwards.",
             "cred8": "The first time the authentication flow is executed, Dropbox will ask to confirm (via two subsequent pages) that this app has access to your Dropbox files.",
             "cred9": "After the authentication flow has ended, the refresh token will be displayed in the popup window.  Copy that token and paste it into the box above.",
-            "cred10": "After the config node has been deployed, it is always possible to <i><a id='node-dropbox-refresh-access-token' href='#' target='_blank'>refresh</a></i> the access token.  Eg. when the permissions of the app has changed, but the old access token still supports the old permissions."
+            "cred10": "If the permissions in the app are updated afterwards, it is required to repeat steps 5 and 6 again. Otherwise the refresh token will continue operating with the original permissions."
         },
-        "text": {
-            "auth-flow": "Dropbox authentication for Node-RED",
-            "access-token-refreshed": "The access token has been refreshed (based on the refresh token)"
+        "title": {
+            "auth-flow": "Dropbox authentication for Node-RED"
             
         },
         "status": {
@@ -52,9 +51,7 @@
             "no-app-key": "No app key specified",
             "auth-url-failed": "failed to determine redirect auth url",
             "download-failed": "download failed __err__",
-            "credentials-error": "Error verifying credentials: __err__",
-            "node-not-deployed": "Only the access token of a deployed config node can be refreshed",
-            "no-refresh-token": "The deployed config node has no refresh token"
+            "credentials-error": "Error verifying credentials: __err__"
         }
     }
 }

--- a/dropbox/locales/en-US/dropbox.json
+++ b/dropbox/locales/en-US/dropbox.json
@@ -27,7 +27,7 @@
             "cred7": "Since the refresh token doesn't expire, this step needs to be executed only once.  But if required, it can be repeated afterwards.",
             "cred8": "The first time the authentication flow is executed, Dropbox will ask to confirm (via two subsequent pages) that this app has access to your Dropbox files.",
             "cred9": "After the authentication flow has ended, the refresh token will be displayed in the popup window.  Copy that token and paste it into the box above.",
-            "cred10": "If the permissions in the app are updated afterwards, it is required to repeat steps 5 and 6 again. Otherwise the refresh token will continue operating with the original permissions."
+            "cred10": "Every time the app permissions are changed afterwards, it is required to revoke the refresh token and to repeat steps 5 and 6 again. Otherwise the refresh token will continue operating with the original permissions."
         },
         "title": {
             "auth-flow": "Dropbox authentication for Node-RED"

--- a/dropbox/locales/en-US/dropbox.json
+++ b/dropbox/locales/en-US/dropbox.json
@@ -21,7 +21,7 @@
             "cred1": "Sign up for an account on <i><a href='https://www.dropbox.com/' target='_blank'>Dropbox</a></i>.",
             "cred2": "Create a new app on <i><a href='https://www.dropbox.com/developers/apps/' target='_blank'>Dropbox developer home</a></i>.  On the subsequent page, select 'Dropbox API app' and choose App folder or Full Dropbox access. And set the required app permissions.",
             "cred3": "On the same page, the 'app key' is displayed.  Copy that key and paste it into the box above.",
-            "cred4": "And on the same page, add the redirect url <span id='node-dropbox-redirect-url'></span>.",
+            "cred4": "And on the same page, add the redirect url <span id='node-dropbox-redirect-url'></span>",
             "cred5": "To obtain a new refresh token, start the (OAuth2) <i><a id='node-dropbox-app-link' href='#' target='_blank'>authentication flow</a></i>.",
             "cred6": "If no popup window appears, it might be necessary to instruct the browser to allow popup windows for this website.",
             "cred7": "Since the refresh token doesn't expire, this step needs to be executed only once.  But if required, it can be repeated afterwards.",

--- a/dropbox/locales/en-US/dropbox.json
+++ b/dropbox/locales/en-US/dropbox.json
@@ -8,7 +8,8 @@
             "local": "Local Filename",
             "appkey": "App Key",
             "appsecret": "App Secret",
-            "accesstoken": "Access Token"
+            "accesstoken": "Access Token",
+            "refreshtoken": "Refresh Token"
         },
         "placeholder": {
             "pattern": "Filepattern",
@@ -17,9 +18,21 @@
             "local": "Local Filename"
         },
         "tip": {
-            "cred1": "To obtain an access token, visit the <i><a href='https://www.dropbox.com/developers/apps/create' target='_new'>Dropbox developer home</a></i>.<br><br>Once signed up:",
-            "cred2": "<ol><li>click 'Create app',</li><li>select 'Dropbox API app',</li><li>choose either App folder or Full Dropbox access,</li><li>choose an app name</li><li>click 'Create app'.</li></ol>",
-            "cred3": "On the subsequent page, click the button to ensure the token does not expire, then  generated an access token. Copy it into the box above."
+            "cred1": "Sign up for an account on <i><a href='https://www.dropbox.com/' target='_blank'>Dropbox</a></i>.",
+            "cred2": "Create a new app on <i><a href='https://www.dropbox.com/developers/apps/' target='_blank'>Dropbox developer home</a></i>.  On the subsequent page, select 'Dropbox API app' and choose App folder or Full Dropbox access. And set the required app permissions.",
+            "cred3": "On the same page, the 'app key' is displayed.  Copy that key and paste it into the box above.",
+            "cred4": "And on the same page, add the redirect url <span id='node-dropbox-redirect-url'></span>.",
+            "cred5": "To obtain a new refresh token, start the (OAuth2) <i><a id='node-dropbox-app-link' href='#' target='_blank'>authentication flow</a></i>.",
+            "cred6": "If no popup window appears, it might be necessary to instruct the browser to allow popup windows for this website.",
+            "cred7": "Since the refresh token doesn't expire, this step needs to be executed only once.  But if required, it can be repeated afterwards.",
+            "cred8": "The first time the authentication flow is executed, Dropbox will ask to confirm (via two subsequent pages) that this app has access to your Dropbox files.",
+            "cred9": "After the authentication flow has ended, the refresh token will be displayed in the popup window.  Copy that token and paste it into the box above.",
+            "cred10": "After the config node has been deployed, it is always possible to <i><a id='node-dropbox-refresh-access-token' href='#' target='_blank'>refresh</a></i> the access token.  Eg. when the permissions of the app has changed, but the old access token still supports the old permissions."
+        },
+        "text": {
+            "auth-flow": "Dropbox authentication for Node-RED",
+            "access-token-refreshed": "The access token has been refreshed (based on the refresh token)"
+            
         },
         "status": {
             "initializing": "initializing",
@@ -37,8 +50,12 @@
             "initialization-failed": "initialization failed __err__",
             "change-fetch-failed": "failed to fetch changes __err__",
             "no-filename": "No filename specified",
+            "no-app-key": "No app key specified",
+            "auth-url-failed": "failed to determine redirect auth url",
             "download-failed": "download failed __err__",
-            "credentials-error": "Error verifying credentials: __err__"
+            "credentials-error": "Error verifying credentials: __err__",
+            "node-not-deployed": "Only the access token of a deployed config node can be refreshed",
+            "no-refresh-token": "The deployed config node has no refresh token"
         }
     }
 }

--- a/dropbox/locales/en-US/dropbox.json
+++ b/dropbox/locales/en-US/dropbox.json
@@ -39,12 +39,11 @@
             "failed": "failed",
             "checking-for-changes": "checking for changes",
             "downloading": "downloading",
-            "checking-credentials": "checking credentials",
             "access-denied": "access denied",
             "uploading": "uploading"
         },
         "warn": {
-            "missing-credentials": "Missing dropbox credentials"
+            "missing-refresh-token": "Missing dropbox refresh token"
         },
         "error": {
             "initialization-failed": "initialization failed __err__",

--- a/dropbox/package.json
+++ b/dropbox/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "dropbox": "^10.32.0",
         "is-utf8": "^0.2.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.1.2"
     },
     "repository": {
         "type": "git",

--- a/dropbox/package.json
+++ b/dropbox/package.json
@@ -1,11 +1,11 @@
 {
     "name": "node-red-node-dropbox",
-    "version": "1.1.1",
+    "version": "2.0.0",
     "description": "Node-RED nodes to watch and download files from Dropbox",
     "dependencies": {
-        "dropbox": "^10.20.0",
+        "dropbox": "^10.32.0",
         "is-utf8": "^0.2.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.0.4"
     },
     "repository": {
         "type": "git",
@@ -32,6 +32,9 @@
         },
         {
             "name": "Ben Hardill"
+        },
+        {
+            "name": "Bart Butenaers"
         }
     ]
 }


### PR DESCRIPTION
## Types of changes
Starting from September 30th 2021, all the new Dropbox access tokens are only 4 hours valid and then they expire.  Instead of entering once the access token in the node's config screen, we should generate a refresh token.  That can be done by having the user to allow (in a popup window) the node to access the API of the Dropbox app (via an oauth2 authorisation flow). That refresh token will be infinite usable, i.e. it will never expire. As soon as a short-life access token expires, the long-life refresh token will be used to generate automatically a new access token. Then that new access token can be used to access the API of the Dropbox app.

This pull request has been discussed on Discourse (see [here](https://discourse.nodered.org/t/refresh-tokens-in-node-red-node-dropbox-pr-proposal/65610)).

- [X] Bugfix (breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
As discussed, the "Access token" field has been replaced by a "Refresh token" field.  Which means that users that own an old access token (which is currently still infinite valid), won't be able to use that token anymore.  Because if we would keep the "Access token" field, this would become confusing for users with refresh tokens: because the short-live access token would be renewed automatically continiously under the cover, but never be available in the "Access token" field on the screen.

As a result, this will be a breaking change.  Therefore we have decided to bump the version number to 2.0.0.

Based on the feedback from the users, there are currently two (known) limitations:
1. The redirect url should be https, unless localhost is used.
2. The redirect url should have the same hostname as the one used to access the Node-RED flow editor.  Which means you can only use localhost in the redirect url, if you use localhost to access the flow editor.  Which is only possible if the browser is hosted on the same server where Node-RED is running.

A [diagram](https://discourse.nodered.org/t/refresh-tokens-in-node-red-node-dropbox-pr-proposal/65610#description-of-the-implementation-3) is also available on Discourse, which visualizes the design of this pull request.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
