### PR TITLE
Updated README.ms changed 'hunidity' to 'humidity'

### DIFF
--- a/openweathermap/README.md
+++ b/openweathermap/README.md
@@ -54,7 +54,7 @@ Current conditions will return
 
  - **dt** - epoch timestamp
  - **pressure** - in hPa
- - **hunidity** - in %
+ - **humidity** - in %
  - **speed** - wind speed in metres per second
  - **deg** - wind direction in degrees
  - **clouds** - cloudiness in %


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Fixed typo in README.md for openweathermap node in the '5 day Forecast will return a 5 part array, each with' section
'humidity' was spelled 'hunidity'

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [na/ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [n/a ] I have run `grunt` to verify the unit tests pass
- [n/a ] I have added suitable unit tests to cover the new/changed functionality
