### PR TITLE
Dropbox refresh token refactoring - frontend code

### DIFF
--- a/dropbox/dropbox.html
+++ b/dropbox/dropbox.html
@@ -16,34 +16,50 @@
 
 <script type="text/x-red" data-template-name="dropbox-config">
     <div class="form-row">
-        <label for="node-config-input-clientid"><span data-i18n="dropbox.label.appkey"></span></label>
-        <input class="input-append-left" type="password" id="node-config-input-clientid" >
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-refreshtoken"><span data-i18n="dropbox.label.refreshtoken"></span></label>
-        <input class="input-append-left" type="password" id="node-config-input-refreshtoken" >
-    </div>
-    <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="dropbox.label.name"></span></label>
         <input type="text" id="node-config-input-name" data-i18n="[placeholder]dropbox.placeholder.name">
     </div>
     <div class="form-tips">
+        <span data-i18n="[html]dropbox.tip.cred1"></span>
         <ol>
-            <li><span data-i18n="[html]dropbox.tip.cred1"></span></li>
             <li><span data-i18n="[html]dropbox.tip.cred2"></span></li>
             <li><span data-i18n="[html]dropbox.tip.cred3"></span></li>
-            <li><span data-i18n="[html]dropbox.tip.cred4"></span></li>
+            <li>
+                <span data-i18n="[html]dropbox.tip.cred4"></span>
+                <div class="form-row">
+                    <label for="node-config-input-clientid"><span data-i18n="dropbox.label.appkey"></span></label>
+                    <input class="input-append-left" type="password" id="node-config-input-clientid" >
+                </div>
+                <div class="form-row">
+                    <label for="node-config-input-clientsecret"><span data-i18n="dropbox.label.appsecret"></span></label>
+                    <input class="input-append-left" type="password" id="node-config-input-clientsecret" >
+                </div>
+            </li>
             <li><span data-i18n="[html]dropbox.tip.cred5"></span></li>
             <ul>
                 <li><span data-i18n="[html]dropbox.tip.cred6"></span></li>
                 <li><span data-i18n="[html]dropbox.tip.cred7"></span></li>
-                <li><span data-i18n="[html]dropbox.tip.cred8"></span></li>
             </ul>
-            <li><span data-i18n="[html]dropbox.tip.cred9"></span></li>
-            <li><span data-i18n="[html]dropbox.tip.cred10"></span></li>
+            <li>
+                <span data-i18n="[html]dropbox.tip.cred8"></span>
+                <div class="form-row">
+                    <label for="node-config-input-accesscode"><span data-i18n="dropbox.label.accesscode"></span></label>
+                    <input class="input-append-left" type="password" id="node-config-input-accesscode" >
+                </div>
+            </li>
+            <li>
+                <span data-i18n="[html]dropbox.tip.cred9"></span>
+                <div class="form-row">
+                    <label for="node-config-input-refreshtoken"><span data-i18n="dropbox.label.refreshtoken"></span></label>
+                    <input class="input-append-left" type="password" id="node-config-input-refreshtoken" >
+                </div>
+            </li>
         </ol>
+        <span data-i18n="[html]dropbox.tip.cred10"></span>
     </div>
 </script>
+
+<script src="https://unpkg.com/js-sha256@0.9.0/src/sha256.js"></script>
 
 <script type="text/javascript">
 (function() {
@@ -54,6 +70,7 @@
         },
         credentials: {
             clientid: {type: "password",required:true},
+            // For security issues, the client secret won't be stored in Node-RED
             refreshtoken: {type: "password",required:true}
         },
         label: function() {
@@ -63,47 +80,114 @@
         oneditprepare: function() { 
             var node = this;
 
+            function base64UrlEncode(str) {
+                var base64String = btoa(str);
+                var base64UrlEncodedString = base64String.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+                return base64UrlEncodedString;
+            }
+            
+            function createBrowserSafeString(str) {
+                var base64str = str.toString('base64')
+                return base64str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+            }
+
             // Use a (zero) timeout because the anchor id's in the data-i18n texts are not known yet at this moment
             setTimeout(function() {
-                $.ajax({
-                    url: "dropbox/generate_redirect_url",
-                    type: "GET",
-                    datatype: 'json',
-                    success: function(data) {
-                        node.redirectUrl = data.redirectUrl;
-                        $("#node-dropbox-redirect-url").html("<b><i>" + data.redirectUrl + "</b></i>");
-                    },
-                    error: function(xhr) {
-                        alert(xhr.responseText);
-                    }
-                });
-            
-                $("#node-dropbox-app-link").click(function(e) {
+                $("#node-dropbox-app-link").click(async function(e) {
                     e.preventDefault();
+debugger;
+                    // The code verifier should be a high-entropy cryptographic random string with a minimum of 43 characters and a maximum of 128 characters. 
+                    // It should only use A-Z, a-z, 0–9, “-”(hyphen), “.” (period), “_”(underscore), “~”(tilde) characters.
+                    var PKCELength = 128;
+                    var array = new Uint8Array(PKCELength);
+                    var randomValueArray = crypto.getRandomValues(array);
+                    var base64RandomString = btoa(randomValueArray);
+                    node.codeVerifier = createBrowserSafeString(base64RandomString).substr(0, 128);
                     
+                    // Convert the code verifier string to an Uint8Array (which is required as input for the sha256 digest hash function)
+                    var encoder = new TextEncoder();
+                    var codeVerifierArray = encoder.encode(node.codeVerifier);
+                    
+                    // The code challenge is created by SHA256 hashing the code_verifier and base64 URL encoding the resulting hash.
+                    // Reason: since the code challenge is sent through the browser it is VERY important that the code challenge is not the same
+                    // as the code verifier.  Because an attacker could gain access to the HTTP request, e.g. via the browser HTTP logs.
+                    // It is advised to use the browser's SHA256 hash calculation (via the Crypto Web API), since these implementations are
+                    // reviewed by experts, and will likely be more secure and reliable than a custom implementation.  However this is only
+                    // available in Chrome in a secure context, which means when operating via an SSL connection (to Node-RED.  Because when the hash 
+                    // would be send over http, that is considered as unsecure.  But for users that have no SSL to Node-RED this is no security issue,
+                    // To solve the absence of the crypto digest function for httpthis we will use a custom SHA256 has function, when the browser doesn't offer it...
+                    // because we won't be sending the hash to Node-RED over http.  Instead we are sending it to Dropbox always via https.
+                    var sha256Hash;
+                    if (crypto && crypto.subtle && crypto.subtle.digest) {
+                        sha256Hash = await crypto.subtle.digest('SHA-256', codeVerifierArray);
+                    }
+                    else {
+                        sha256Obj = sha256.create();
+                        sha256Obj.update(codeVerifierArray);
+                        sha256Hash = sha256Obj.array();
+                    }
+
+                    var base64Sha256Hash = btoa(String.fromCharCode.apply(null, new Uint8Array(sha256Hash)));
+                    var codeChallenge = createBrowserSafeString(base64Sha256Hash).substr(0, 128);
+                    
+                    var clientId = $("#node-config-input-clientid").val();
+                    
+                    if (!clientId || clientId === '__PWRD__') {
+                        // Once the credential has been deployed, it will be replaced in the frontend by the string '__PWRD__'
+                        // Since this cannot be send to Dropbox, we will need to ask the user to enter not only the App Secret but also the App Key (= client id)
+                        RED.notify(node._("dropbox.error.no-app-key"), { type: "error", timeout: 15000 });
+                        return;
+                    }
+
+                    // Compose the Dropbox authentication url here in the frontend.  By adding the code challenge parameter, Dropbox will start an
+                    // authentication flow of type PKCE.  Such a flow is more trusted by Dropbox, and as a result later on the backend only needs to
+                    // pass the refresh token and the app key (= client id) to Dropbox.  So no app secret needs to be stored or send afterwards, thanks
+                    // to the secure PKCE flow we are initiating here...
+                    node.authUrl = "https://www.dropbox.com/oauth2/authorize?client_id=" + clientId + "&token_access_type=offline&response_type=code&code_challenge_method=S256&code_challenge=" + codeChallenge;
+
+                    // Contact the Dropbox authentication server via the authentication url, so that Dropbox can display some wizard screens in a popup window.
+                    // Note that the browser settings might to be adjusted to allow popups.
+                    var popup = window.open(node.authUrl, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
+                    popup.document.title = node._("dropbox.title.auth-flow");
+                });
+                
+                $("#node-dropbox-generate-refresh-token").click(function(e) {
+                    e.preventDefault();
+
+                    var data = {
+                        code: $("#node-config-input-accesscode").val(),
+                        grant_type: "authorization_code",
+                        client_id: $("#node-config-input-clientid").val(),
+                        code_verifier: node.codeVerifier
+                    };
+                    
+                    // Get a refresh token (based on the generated access code) from Dropbox and store it in the "Refresh Token" field.
+                    // By passing the code verifier, Dropbox knows that this request is executed by the same client that started the
+                    // authentication flow above.  When requesting the refresh token we need to pass the code verifier, not the code 
+                    // challenge. Dropbox will calculate the challenge hash itself (based on the same code verifier that we have passed),
+                    // and compare it with the code challenge that it stored when the user granted access with the authorize request.
                     $.ajax({
-                        url: "dropbox/generate_authentication_url",
-                        type: "GET",
-                        data: { 
-                            nodeId: node.id,
-                            clientid: $("#node-config-input-clientid").val().trim(),
-                            redirectUrl: node.redirectUrl
+                        type: 'POST',
+                        url: 'https://api.dropboxapi.com/oauth2/token',
+                        data: $.param(data),
+                        dataType: "json",
+                        beforeSend: function(request) {
+                            request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
                         },
-                        datatype: 'json',
                         success: function(data) {
-                            var authUrl = data.authUrl;
-                            // Don't use a redirect (http 302) in the 'generate_authentication_url' endpoint, because redirecting this
-                            // ajax call to a remote host (i.e. a non Node-RED host) will result in CORS issues.
-                            // Therefore the endpoint will return simply the url of the Dropbox authentication server, and the url
-                            // will be opened here in a popup window.  Note that the browser settings might to be adjusted to allow popups.
-                            var popup = window.open(authUrl, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
-                            popup.document.title = node._("dropbox.title.auth-flow");
+                            // Show the generated refresh token simply in an popup box, so the value optionally can be copied.
+                            // Moreover we don't want it to be stored somewhere in some logs...
+                            // Use a prompt box instead of an alert box, to make sure the user can copy the refresh token.
+                            prompt(node._("dropbox.info.refresh-token-generated"), data.refresh_token);
+                            
+                            // Store the new generated value automatically in the "Refresh token" input field
+                            $("#node-config-input-refreshtoken").val(data.refresh_token);
                         },
                         error: function(xhr) {
-                            alert(xhr.responseText);
+                            RED.notify(xhr.responseJSON.error_description || xhr.responseJSON.error, { type: "error", timeout: 15000 });
                         }
                     });
-                });               
+                });
             }, 0);
         }
     });

--- a/dropbox/dropbox.js
+++ b/dropbox/dropbox.js
@@ -24,7 +24,10 @@ module.exports = function(RED) {
 
     function DropboxNode(n) {
         RED.nodes.createNode(this,n);
+
         this.dropbox = new Dropbox({
+            // Since the refresh token has been obtained via a secure PKCE authentication flow, Dropbox only requires
+            // the refresh token and the App Key (= client id).  But in this case no App Secret is required...
             clientId: this.credentials.clientid,
             refreshToken: this.credentials.refreshtoken
         });
@@ -325,96 +328,4 @@ module.exports = function(RED) {
         });
     }
     RED.nodes.registerType("dropbox out",DropboxOutNode);
-
-    var globalDropboxInstance = null;
-
-    RED.httpAdmin.get('/dropbox/generate_redirect_url', function(req, res) {
-        // Once the Dropbox authentication server has finished its authentication flow, it will send the results (incl. the refresh token) to our redirect url.
-        // Since the Dropbox instance (= the dropbox client) is executing the redirect, "localhost" will also be a valid host.
-        // Parts of the original will be reused, to make sure all path related settings.js adjustments are used here.
-        var redirectUrl = req.protocol + "://" + req.get('host') + req.originalUrl.replace("generate_redirect_url", "authenticate");
-        res.json({redirectUrl: redirectUrl});
-    });
-
-    RED.httpAdmin.get('/dropbox/generate_authentication_url', function(req, res) {
-        var options = {};
-
-        // When the config node has been deployed previously, it might contain deployed settings which need to be used
-        var dropboxNode = RED.nodes.getNode(req.query.nodeId);
-        if(dropboxNode) {
-            options.clientId = dropboxNode.credentials.clientid;
-        }
-        
-        // The config node's config screen might contain an undeployed clientId, which will override the client id from the deployed config node settings.
-        if (req.query.clientid && req.query.clientid !== "__PWRD__") {
-            options.clientId = req.query.clientid;
-        }
-        
-        if (!options.clientId) {
-            res.writeHead(500);
-            res.end(RED._("dropbox.error.no-app-key"));
-            return;
-        }
-
-        // Pass the redirect uri to our second 'authenticate' endpoint via the session state, because getAccessTokenFromCode needs the redirectUri we have been using here. 
-        var state = JSON.stringify({redirectUri: req.query.redirectUrl});
-
-        try {
-            // Create a new temporary Dropbox instance, because at this moment the config node (and its Dropbox instance) might not have been deployed yet.
-            var tempDropbox = new Dropbox(options);
-
-            // Get the authentication URL of this client app, to start an authentication flow on the Dropbox authentication server.
-            // The 'offline' argument is required to get a (long-lived) refresh token.  Because offline applications will access the API, without
-            // the manual intervention of an end user.  That refresh token can be used afterwards to obtain a new (short-lived) access token.
-            var authUrl = tempDropbox.auth.getAuthenticationUrl(req.query.redirectUrl, state, 'code', 'offline', null, 'none', true)
-            .then(function(authUrl) {
-                // In the next 'authenticate' endpoint, again a Dropbox instance will be needed.  Pass the current dropbox instance to the next endpoint, because
-                // (as a result of the getAuthenticationUrl call) it's 'codeVerifier' property will be filled in.  And that property is needed to call
-                // getAccessTokenFromCode in the next endpoint, to avoid having the user to go throught an entire Authorization Code Flow (with PKCE).
-                // Reusing the Dropbox instance seems more secure, compared to pass the codeVerifier via the session state to the next endpoint.
-                globalDropboxInstance = tempDropbox;
-    
-                // Redirect the request from the Node-RED flow editor to the Dropbox authentication server.
-                // The user should manually confirm (in the Dropbox authentication page) that this client app can be linked to the dropbox account.
-                // This starts the OAuth 2.0 authorization flow. This isn't an API call—it's the web page that lets the user sign in to Dropbox and authorize your app. 
-                // After the user decides whether or not to authorize your app, they will be redirected to the URI specified by redirect_uri.
-                res.json({authUrl: authUrl});
-            })
-            .catch(function(error) {
-                res.writeHead(500);
-                res.end(RED._("dropbox.error.auth-url-failed"));
-                return;
-            })
-        }
-        catch(err) {
-            res.writeHead(500);
-            res.end(err.message);            
-        }
-    });
-
-    // Dropbox will call this endpoint as soon as i authentication flow has ended
-    RED.httpAdmin.get('/dropbox/authenticate', function(req, res) {
-        var accessCode = req.query.code;
-        var state = JSON.parse(req.query.state);
-
-        // Ask Dropbox for an access token (and refresh token), based on the access code that we have received.
-        // Note that redirectUri won't be called again here, but the URL needs to be exactly the same as the one that has been called previously (in getAuthenticationUrl).
-        // Show the refresh token in the popup window, where it can be copied by the user and pasted into the config node's screen.
-        globalDropboxInstance.auth.getAccessTokenFromCode(state.redirectUri, accessCode)
-        .then(function(response) {
-            res.setHeader("Content-Type", "text/html");
-            res.writeHead(200);
-            
-            // The response contains two tokens (but only the refresh token is relevant for our use case):
-            // 1.- A (long-lived) refresh token which will never expire.
-            // 2.- A (short-lived) access token which will expire after 4 hours.  Note such tokens start with "sl.".
-            var html = "<html><head><title>" +  RED._("dropbox.title.auth-flow") + "</title></head><body><h1>" + RED._("dropbox.label.refreshtoken") + "</h1>" + response.result.refresh_token + "</body></html>";
-            res.end(html);
-            globalDropboxInstance = null;
-        })
-        .catch(function(error) {
-            res.writeHead(500);
-            res.end(err.message);
-        });
-    });
 };

--- a/dropbox/locales/en-US/dropbox.json
+++ b/dropbox/locales/en-US/dropbox.json
@@ -9,6 +9,7 @@
             "appkey": "App Key",
             "appsecret": "App Secret",
             "accesstoken": "Access Token",
+            "accesscode": "Access Code",
             "refreshtoken": "Refresh Token"
         },
         "placeholder": {
@@ -18,16 +19,16 @@
             "local": "Local Filename"
         },
         "tip": {
-            "cred1": "Sign up for an account on <i><a href='https://www.dropbox.com/' target='_blank'>Dropbox</a></i>.",
-            "cred2": "Create a new app on <i><a href='https://www.dropbox.com/developers/apps/' target='_blank'>Dropbox developer home</a></i>.  On the subsequent page, select 'Dropbox API app' and choose App folder or Full Dropbox access. And set the required app permissions.",
-            "cred3": "On the same page, the 'app key' is displayed.  Copy that key and paste it into the box above.",
-            "cred4": "And on the same page, add the redirect url <span id='node-dropbox-redirect-url'></span>",
-            "cred5": "To obtain a new refresh token, start the (OAuth2) <i><a id='node-dropbox-app-link' href='#' target='_blank'>authentication flow</a></i>.",
+            "cred1": "Get a refresh token via the steps below.  Note that only the App Key and the Refresh Token will be stored in Node-RED, to minimize security issues.  It is highly advised to execute the below steps across an <b>SSL</b> connection to Node-RED!",
+            "cred2": "Sign up for an account on <i><a href='https://www.dropbox.com/' target='_blank'>Dropbox</a></i>.",
+            "cred3": "Create a new app on <i><a href='https://www.dropbox.com/developers/apps/' target='_blank'>Dropbox developer home</a></i>.  On the subsequent page, select 'Dropbox API app' and choose App folder or Full Dropbox access. And set the required app permissions.",
+            "cred4": "Copy both the 'app key' and 'app secret' from that page to here:",
+            "cred5": "Start an (OAuth2) <i><a id='node-dropbox-app-link' href='#' target='_blank'>authentication flow</a></i> to obtain an access code.",
             "cred6": "If no popup window appears, it might be necessary to instruct the browser to allow popup windows for this website.",
-            "cred7": "Since the refresh token doesn't expire, this step needs to be executed only once.  But if required, it can be repeated afterwards.",
-            "cred8": "The first time the authentication flow is executed, Dropbox will ask to confirm (via two subsequent pages) that this app has access to your Dropbox files.",
-            "cred9": "After the authentication flow has ended, the refresh token will be displayed in the popup window.  Copy that token and paste it into the box above.",
-            "cred10": "Every time the app permissions are changed afterwards, it is required to revoke the refresh token and to repeat steps 5 and 6 again. Otherwise the refresh token will continue operating with the original permissions."
+            "cred7": "The first time the authentication flow is executed, Dropbox will ask to confirm (via two subsequent pages) that this app has access to your Dropbox files.",
+            "cred8": "Copy the access code from the last popup window of the authentication flow to here:",
+            "cred9": "Use this access code to <i><a id='node-dropbox-generate-refresh-token' href='#' target='_blank'>request</a></i> a new refresh token.",
+            "cred10": "Every time the app permissions are changed afterwards, it is required to revoke the refresh token and to repeat steps 4 and 5 again. Otherwise the refresh token will continue operating with the original permissions."
         },
         "title": {
             "auth-flow": "Dropbox authentication for Node-RED"
@@ -40,6 +41,9 @@
             "downloading": "downloading",
             "access-denied": "access denied",
             "uploading": "uploading"
+        },
+        "info": {
+            "refresh-token-generated": "The refresh token has been generated and copied already automatically to the 'Refresh Token' input field."
         },
         "warn": {
             "missing-refresh-token": "Missing dropbox refresh token"

--- a/dropbox/package.json
+++ b/dropbox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-node-dropbox",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Node-RED nodes to watch and download files from Dropbox",
     "dependencies": {
         "dropbox": "^10.32.0",

--- a/dropbox/resources/sha256.js
+++ b/dropbox/resources/sha256.js
@@ -1,0 +1,518 @@
+/**
+ * [js-sha256]{@link https://github.com/emn178/js-sha256}
+ *
+ * @version 0.9.0
+ * @author Chen, Yi-Cyuan [emn178@gmail.com]
+ * @copyright Chen, Yi-Cyuan 2014-2017
+ * @license MIT
+ */
+/*jslint bitwise: true */
+(function () {
+  'use strict';
+
+  var ERROR = 'input is invalid type';
+  var WINDOW = typeof window === 'object';
+  var root = WINDOW ? window : {};
+  if (root.JS_SHA256_NO_WINDOW) {
+    WINDOW = false;
+  }
+  var WEB_WORKER = !WINDOW && typeof self === 'object';
+  var NODE_JS = !root.JS_SHA256_NO_NODE_JS && typeof process === 'object' && process.versions && process.versions.node;
+  if (NODE_JS) {
+    root = global;
+  } else if (WEB_WORKER) {
+    root = self;
+  }
+  var COMMON_JS = !root.JS_SHA256_NO_COMMON_JS && typeof module === 'object' && module.exports;
+  var AMD = typeof define === 'function' && define.amd;
+  var ARRAY_BUFFER = !root.JS_SHA256_NO_ARRAY_BUFFER && typeof ArrayBuffer !== 'undefined';
+  var HEX_CHARS = '0123456789abcdef'.split('');
+  var EXTRA = [-2147483648, 8388608, 32768, 128];
+  var SHIFT = [24, 16, 8, 0];
+  var K = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+  ];
+  var OUTPUT_TYPES = ['hex', 'array', 'digest', 'arrayBuffer'];
+
+  var blocks = [];
+
+  if (root.JS_SHA256_NO_NODE_JS || !Array.isArray) {
+    Array.isArray = function (obj) {
+      return Object.prototype.toString.call(obj) === '[object Array]';
+    };
+  }
+
+  if (ARRAY_BUFFER && (root.JS_SHA256_NO_ARRAY_BUFFER_IS_VIEW || !ArrayBuffer.isView)) {
+    ArrayBuffer.isView = function (obj) {
+      return typeof obj === 'object' && obj.buffer && obj.buffer.constructor === ArrayBuffer;
+    };
+  }
+
+  var createOutputMethod = function (outputType, is224) {
+    return function (message) {
+      return new Sha256(is224, true).update(message)[outputType]();
+    };
+  };
+
+  var createMethod = function (is224) {
+    var method = createOutputMethod('hex', is224);
+    if (NODE_JS) {
+      method = nodeWrap(method, is224);
+    }
+    method.create = function () {
+      return new Sha256(is224);
+    };
+    method.update = function (message) {
+      return method.create().update(message);
+    };
+    for (var i = 0; i < OUTPUT_TYPES.length; ++i) {
+      var type = OUTPUT_TYPES[i];
+      method[type] = createOutputMethod(type, is224);
+    }
+    return method;
+  };
+
+  var nodeWrap = function (method, is224) {
+    var crypto = eval("require('crypto')");
+    var Buffer = eval("require('buffer').Buffer");
+    var algorithm = is224 ? 'sha224' : 'sha256';
+    var nodeMethod = function (message) {
+      if (typeof message === 'string') {
+        return crypto.createHash(algorithm).update(message, 'utf8').digest('hex');
+      } else {
+        if (message === null || message === undefined) {
+          throw new Error(ERROR);
+        } else if (message.constructor === ArrayBuffer) {
+          message = new Uint8Array(message);
+        }
+      }
+      if (Array.isArray(message) || ArrayBuffer.isView(message) ||
+        message.constructor === Buffer) {
+        return crypto.createHash(algorithm).update(new Buffer(message)).digest('hex');
+      } else {
+        return method(message);
+      }
+    };
+    return nodeMethod;
+  };
+
+  var createHmacOutputMethod = function (outputType, is224) {
+    return function (key, message) {
+      return new HmacSha256(key, is224, true).update(message)[outputType]();
+    };
+  };
+
+  var createHmacMethod = function (is224) {
+    var method = createHmacOutputMethod('hex', is224);
+    method.create = function (key) {
+      return new HmacSha256(key, is224);
+    };
+    method.update = function (key, message) {
+      return method.create(key).update(message);
+    };
+    for (var i = 0; i < OUTPUT_TYPES.length; ++i) {
+      var type = OUTPUT_TYPES[i];
+      method[type] = createHmacOutputMethod(type, is224);
+    }
+    return method;
+  };
+
+  function Sha256(is224, sharedMemory) {
+    if (sharedMemory) {
+      blocks[0] = blocks[16] = blocks[1] = blocks[2] = blocks[3] =
+        blocks[4] = blocks[5] = blocks[6] = blocks[7] =
+        blocks[8] = blocks[9] = blocks[10] = blocks[11] =
+        blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      this.blocks = blocks;
+    } else {
+      this.blocks = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    }
+
+    if (is224) {
+      this.h0 = 0xc1059ed8;
+      this.h1 = 0x367cd507;
+      this.h2 = 0x3070dd17;
+      this.h3 = 0xf70e5939;
+      this.h4 = 0xffc00b31;
+      this.h5 = 0x68581511;
+      this.h6 = 0x64f98fa7;
+      this.h7 = 0xbefa4fa4;
+    } else { // 256
+      this.h0 = 0x6a09e667;
+      this.h1 = 0xbb67ae85;
+      this.h2 = 0x3c6ef372;
+      this.h3 = 0xa54ff53a;
+      this.h4 = 0x510e527f;
+      this.h5 = 0x9b05688c;
+      this.h6 = 0x1f83d9ab;
+      this.h7 = 0x5be0cd19;
+    }
+
+    this.block = this.start = this.bytes = this.hBytes = 0;
+    this.finalized = this.hashed = false;
+    this.first = true;
+    this.is224 = is224;
+  }
+
+  Sha256.prototype.update = function (message) {
+    if (this.finalized) {
+      return;
+    }
+    var notString, type = typeof message;
+    if (type !== 'string') {
+      if (type === 'object') {
+        if (message === null) {
+          throw new Error(ERROR);
+        } else if (ARRAY_BUFFER && message.constructor === ArrayBuffer) {
+          message = new Uint8Array(message);
+        } else if (!Array.isArray(message)) {
+          if (!ARRAY_BUFFER || !ArrayBuffer.isView(message)) {
+            throw new Error(ERROR);
+          }
+        }
+      } else {
+        throw new Error(ERROR);
+      }
+      notString = true;
+    }
+    var code, index = 0, i, length = message.length, blocks = this.blocks;
+
+    while (index < length) {
+      if (this.hashed) {
+        this.hashed = false;
+        blocks[0] = this.block;
+        blocks[16] = blocks[1] = blocks[2] = blocks[3] =
+          blocks[4] = blocks[5] = blocks[6] = blocks[7] =
+          blocks[8] = blocks[9] = blocks[10] = blocks[11] =
+          blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+      }
+
+      if (notString) {
+        for (i = this.start; index < length && i < 64; ++index) {
+          blocks[i >> 2] |= message[index] << SHIFT[i++ & 3];
+        }
+      } else {
+        for (i = this.start; index < length && i < 64; ++index) {
+          code = message.charCodeAt(index);
+          if (code < 0x80) {
+            blocks[i >> 2] |= code << SHIFT[i++ & 3];
+          } else if (code < 0x800) {
+            blocks[i >> 2] |= (0xc0 | (code >> 6)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+          } else if (code < 0xd800 || code >= 0xe000) {
+            blocks[i >> 2] |= (0xe0 | (code >> 12)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+          } else {
+            code = 0x10000 + (((code & 0x3ff) << 10) | (message.charCodeAt(++index) & 0x3ff));
+            blocks[i >> 2] |= (0xf0 | (code >> 18)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | ((code >> 12) & 0x3f)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
+            blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+          }
+        }
+      }
+
+      this.lastByteIndex = i;
+      this.bytes += i - this.start;
+      if (i >= 64) {
+        this.block = blocks[16];
+        this.start = i - 64;
+        this.hash();
+        this.hashed = true;
+      } else {
+        this.start = i;
+      }
+    }
+    if (this.bytes > 4294967295) {
+      this.hBytes += this.bytes / 4294967296 << 0;
+      this.bytes = this.bytes % 4294967296;
+    }
+    return this;
+  };
+
+  Sha256.prototype.finalize = function () {
+    if (this.finalized) {
+      return;
+    }
+    this.finalized = true;
+    var blocks = this.blocks, i = this.lastByteIndex;
+    blocks[16] = this.block;
+    blocks[i >> 2] |= EXTRA[i & 3];
+    this.block = blocks[16];
+    if (i >= 56) {
+      if (!this.hashed) {
+        this.hash();
+      }
+      blocks[0] = this.block;
+      blocks[16] = blocks[1] = blocks[2] = blocks[3] =
+        blocks[4] = blocks[5] = blocks[6] = blocks[7] =
+        blocks[8] = blocks[9] = blocks[10] = blocks[11] =
+        blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+    }
+    blocks[14] = this.hBytes << 3 | this.bytes >>> 29;
+    blocks[15] = this.bytes << 3;
+    this.hash();
+  };
+
+  Sha256.prototype.hash = function () {
+    var a = this.h0, b = this.h1, c = this.h2, d = this.h3, e = this.h4, f = this.h5, g = this.h6,
+      h = this.h7, blocks = this.blocks, j, s0, s1, maj, t1, t2, ch, ab, da, cd, bc;
+
+    for (j = 16; j < 64; ++j) {
+      // rightrotate
+      t1 = blocks[j - 15];
+      s0 = ((t1 >>> 7) | (t1 << 25)) ^ ((t1 >>> 18) | (t1 << 14)) ^ (t1 >>> 3);
+      t1 = blocks[j - 2];
+      s1 = ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^ (t1 >>> 10);
+      blocks[j] = blocks[j - 16] + s0 + blocks[j - 7] + s1 << 0;
+    }
+
+    bc = b & c;
+    for (j = 0; j < 64; j += 4) {
+      if (this.first) {
+        if (this.is224) {
+          ab = 300032;
+          t1 = blocks[0] - 1413257819;
+          h = t1 - 150054599 << 0;
+          d = t1 + 24177077 << 0;
+        } else {
+          ab = 704751109;
+          t1 = blocks[0] - 210244248;
+          h = t1 - 1521486534 << 0;
+          d = t1 + 143694565 << 0;
+        }
+        this.first = false;
+      } else {
+        s0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^ ((a >>> 22) | (a << 10));
+        s1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^ ((e >>> 25) | (e << 7));
+        ab = a & b;
+        maj = ab ^ (a & c) ^ bc;
+        ch = (e & f) ^ (~e & g);
+        t1 = h + s1 + ch + K[j] + blocks[j];
+        t2 = s0 + maj;
+        h = d + t1 << 0;
+        d = t1 + t2 << 0;
+      }
+      s0 = ((d >>> 2) | (d << 30)) ^ ((d >>> 13) | (d << 19)) ^ ((d >>> 22) | (d << 10));
+      s1 = ((h >>> 6) | (h << 26)) ^ ((h >>> 11) | (h << 21)) ^ ((h >>> 25) | (h << 7));
+      da = d & a;
+      maj = da ^ (d & b) ^ ab;
+      ch = (h & e) ^ (~h & f);
+      t1 = g + s1 + ch + K[j + 1] + blocks[j + 1];
+      t2 = s0 + maj;
+      g = c + t1 << 0;
+      c = t1 + t2 << 0;
+      s0 = ((c >>> 2) | (c << 30)) ^ ((c >>> 13) | (c << 19)) ^ ((c >>> 22) | (c << 10));
+      s1 = ((g >>> 6) | (g << 26)) ^ ((g >>> 11) | (g << 21)) ^ ((g >>> 25) | (g << 7));
+      cd = c & d;
+      maj = cd ^ (c & a) ^ da;
+      ch = (g & h) ^ (~g & e);
+      t1 = f + s1 + ch + K[j + 2] + blocks[j + 2];
+      t2 = s0 + maj;
+      f = b + t1 << 0;
+      b = t1 + t2 << 0;
+      s0 = ((b >>> 2) | (b << 30)) ^ ((b >>> 13) | (b << 19)) ^ ((b >>> 22) | (b << 10));
+      s1 = ((f >>> 6) | (f << 26)) ^ ((f >>> 11) | (f << 21)) ^ ((f >>> 25) | (f << 7));
+      bc = b & c;
+      maj = bc ^ (b & d) ^ cd;
+      ch = (f & g) ^ (~f & h);
+      t1 = e + s1 + ch + K[j + 3] + blocks[j + 3];
+      t2 = s0 + maj;
+      e = a + t1 << 0;
+      a = t1 + t2 << 0;
+    }
+
+    this.h0 = this.h0 + a << 0;
+    this.h1 = this.h1 + b << 0;
+    this.h2 = this.h2 + c << 0;
+    this.h3 = this.h3 + d << 0;
+    this.h4 = this.h4 + e << 0;
+    this.h5 = this.h5 + f << 0;
+    this.h6 = this.h6 + g << 0;
+    this.h7 = this.h7 + h << 0;
+  };
+
+  Sha256.prototype.hex = function () {
+    this.finalize();
+
+    var h0 = this.h0, h1 = this.h1, h2 = this.h2, h3 = this.h3, h4 = this.h4, h5 = this.h5,
+      h6 = this.h6, h7 = this.h7;
+
+    var hex = HEX_CHARS[(h0 >> 28) & 0x0F] + HEX_CHARS[(h0 >> 24) & 0x0F] +
+      HEX_CHARS[(h0 >> 20) & 0x0F] + HEX_CHARS[(h0 >> 16) & 0x0F] +
+      HEX_CHARS[(h0 >> 12) & 0x0F] + HEX_CHARS[(h0 >> 8) & 0x0F] +
+      HEX_CHARS[(h0 >> 4) & 0x0F] + HEX_CHARS[h0 & 0x0F] +
+      HEX_CHARS[(h1 >> 28) & 0x0F] + HEX_CHARS[(h1 >> 24) & 0x0F] +
+      HEX_CHARS[(h1 >> 20) & 0x0F] + HEX_CHARS[(h1 >> 16) & 0x0F] +
+      HEX_CHARS[(h1 >> 12) & 0x0F] + HEX_CHARS[(h1 >> 8) & 0x0F] +
+      HEX_CHARS[(h1 >> 4) & 0x0F] + HEX_CHARS[h1 & 0x0F] +
+      HEX_CHARS[(h2 >> 28) & 0x0F] + HEX_CHARS[(h2 >> 24) & 0x0F] +
+      HEX_CHARS[(h2 >> 20) & 0x0F] + HEX_CHARS[(h2 >> 16) & 0x0F] +
+      HEX_CHARS[(h2 >> 12) & 0x0F] + HEX_CHARS[(h2 >> 8) & 0x0F] +
+      HEX_CHARS[(h2 >> 4) & 0x0F] + HEX_CHARS[h2 & 0x0F] +
+      HEX_CHARS[(h3 >> 28) & 0x0F] + HEX_CHARS[(h3 >> 24) & 0x0F] +
+      HEX_CHARS[(h3 >> 20) & 0x0F] + HEX_CHARS[(h3 >> 16) & 0x0F] +
+      HEX_CHARS[(h3 >> 12) & 0x0F] + HEX_CHARS[(h3 >> 8) & 0x0F] +
+      HEX_CHARS[(h3 >> 4) & 0x0F] + HEX_CHARS[h3 & 0x0F] +
+      HEX_CHARS[(h4 >> 28) & 0x0F] + HEX_CHARS[(h4 >> 24) & 0x0F] +
+      HEX_CHARS[(h4 >> 20) & 0x0F] + HEX_CHARS[(h4 >> 16) & 0x0F] +
+      HEX_CHARS[(h4 >> 12) & 0x0F] + HEX_CHARS[(h4 >> 8) & 0x0F] +
+      HEX_CHARS[(h4 >> 4) & 0x0F] + HEX_CHARS[h4 & 0x0F] +
+      HEX_CHARS[(h5 >> 28) & 0x0F] + HEX_CHARS[(h5 >> 24) & 0x0F] +
+      HEX_CHARS[(h5 >> 20) & 0x0F] + HEX_CHARS[(h5 >> 16) & 0x0F] +
+      HEX_CHARS[(h5 >> 12) & 0x0F] + HEX_CHARS[(h5 >> 8) & 0x0F] +
+      HEX_CHARS[(h5 >> 4) & 0x0F] + HEX_CHARS[h5 & 0x0F] +
+      HEX_CHARS[(h6 >> 28) & 0x0F] + HEX_CHARS[(h6 >> 24) & 0x0F] +
+      HEX_CHARS[(h6 >> 20) & 0x0F] + HEX_CHARS[(h6 >> 16) & 0x0F] +
+      HEX_CHARS[(h6 >> 12) & 0x0F] + HEX_CHARS[(h6 >> 8) & 0x0F] +
+      HEX_CHARS[(h6 >> 4) & 0x0F] + HEX_CHARS[h6 & 0x0F];
+    if (!this.is224) {
+      hex += HEX_CHARS[(h7 >> 28) & 0x0F] + HEX_CHARS[(h7 >> 24) & 0x0F] +
+        HEX_CHARS[(h7 >> 20) & 0x0F] + HEX_CHARS[(h7 >> 16) & 0x0F] +
+        HEX_CHARS[(h7 >> 12) & 0x0F] + HEX_CHARS[(h7 >> 8) & 0x0F] +
+        HEX_CHARS[(h7 >> 4) & 0x0F] + HEX_CHARS[h7 & 0x0F];
+    }
+    return hex;
+  };
+
+  Sha256.prototype.toString = Sha256.prototype.hex;
+
+  Sha256.prototype.digest = function () {
+    this.finalize();
+
+    var h0 = this.h0, h1 = this.h1, h2 = this.h2, h3 = this.h3, h4 = this.h4, h5 = this.h5,
+      h6 = this.h6, h7 = this.h7;
+
+    var arr = [
+      (h0 >> 24) & 0xFF, (h0 >> 16) & 0xFF, (h0 >> 8) & 0xFF, h0 & 0xFF,
+      (h1 >> 24) & 0xFF, (h1 >> 16) & 0xFF, (h1 >> 8) & 0xFF, h1 & 0xFF,
+      (h2 >> 24) & 0xFF, (h2 >> 16) & 0xFF, (h2 >> 8) & 0xFF, h2 & 0xFF,
+      (h3 >> 24) & 0xFF, (h3 >> 16) & 0xFF, (h3 >> 8) & 0xFF, h3 & 0xFF,
+      (h4 >> 24) & 0xFF, (h4 >> 16) & 0xFF, (h4 >> 8) & 0xFF, h4 & 0xFF,
+      (h5 >> 24) & 0xFF, (h5 >> 16) & 0xFF, (h5 >> 8) & 0xFF, h5 & 0xFF,
+      (h6 >> 24) & 0xFF, (h6 >> 16) & 0xFF, (h6 >> 8) & 0xFF, h6 & 0xFF
+    ];
+    if (!this.is224) {
+      arr.push((h7 >> 24) & 0xFF, (h7 >> 16) & 0xFF, (h7 >> 8) & 0xFF, h7 & 0xFF);
+    }
+    return arr;
+  };
+
+  Sha256.prototype.array = Sha256.prototype.digest;
+
+  Sha256.prototype.arrayBuffer = function () {
+    this.finalize();
+
+    var buffer = new ArrayBuffer(this.is224 ? 28 : 32);
+    var dataView = new DataView(buffer);
+    dataView.setUint32(0, this.h0);
+    dataView.setUint32(4, this.h1);
+    dataView.setUint32(8, this.h2);
+    dataView.setUint32(12, this.h3);
+    dataView.setUint32(16, this.h4);
+    dataView.setUint32(20, this.h5);
+    dataView.setUint32(24, this.h6);
+    if (!this.is224) {
+      dataView.setUint32(28, this.h7);
+    }
+    return buffer;
+  };
+
+  function HmacSha256(key, is224, sharedMemory) {
+    var i, type = typeof key;
+    if (type === 'string') {
+      var bytes = [], length = key.length, index = 0, code;
+      for (i = 0; i < length; ++i) {
+        code = key.charCodeAt(i);
+        if (code < 0x80) {
+          bytes[index++] = code;
+        } else if (code < 0x800) {
+          bytes[index++] = (0xc0 | (code >> 6));
+          bytes[index++] = (0x80 | (code & 0x3f));
+        } else if (code < 0xd800 || code >= 0xe000) {
+          bytes[index++] = (0xe0 | (code >> 12));
+          bytes[index++] = (0x80 | ((code >> 6) & 0x3f));
+          bytes[index++] = (0x80 | (code & 0x3f));
+        } else {
+          code = 0x10000 + (((code & 0x3ff) << 10) | (key.charCodeAt(++i) & 0x3ff));
+          bytes[index++] = (0xf0 | (code >> 18));
+          bytes[index++] = (0x80 | ((code >> 12) & 0x3f));
+          bytes[index++] = (0x80 | ((code >> 6) & 0x3f));
+          bytes[index++] = (0x80 | (code & 0x3f));
+        }
+      }
+      key = bytes;
+    } else {
+      if (type === 'object') {
+        if (key === null) {
+          throw new Error(ERROR);
+        } else if (ARRAY_BUFFER && key.constructor === ArrayBuffer) {
+          key = new Uint8Array(key);
+        } else if (!Array.isArray(key)) {
+          if (!ARRAY_BUFFER || !ArrayBuffer.isView(key)) {
+            throw new Error(ERROR);
+          }
+        }
+      } else {
+        throw new Error(ERROR);
+      }
+    }
+
+    if (key.length > 64) {
+      key = (new Sha256(is224, true)).update(key).array();
+    }
+
+    var oKeyPad = [], iKeyPad = [];
+    for (i = 0; i < 64; ++i) {
+      var b = key[i] || 0;
+      oKeyPad[i] = 0x5c ^ b;
+      iKeyPad[i] = 0x36 ^ b;
+    }
+
+    Sha256.call(this, is224, sharedMemory);
+
+    this.update(iKeyPad);
+    this.oKeyPad = oKeyPad;
+    this.inner = true;
+    this.sharedMemory = sharedMemory;
+  }
+  HmacSha256.prototype = new Sha256();
+
+  HmacSha256.prototype.finalize = function () {
+    Sha256.prototype.finalize.call(this);
+    if (this.inner) {
+      this.inner = false;
+      var innerHash = this.array();
+      Sha256.call(this, this.is224, this.sharedMemory);
+      this.update(this.oKeyPad);
+      this.update(innerHash);
+      Sha256.prototype.finalize.call(this);
+    }
+  };
+
+  var exports = createMethod();
+  exports.sha256 = exports;
+  exports.sha224 = createMethod(true);
+  exports.sha256.hmac = createHmacMethod();
+  exports.sha224.hmac = createHmacMethod(true);
+
+  if (COMMON_JS) {
+    module.exports = exports;
+  } else {
+    root.sha256 = exports.sha256;
+    root.sha224 = exports.sha224;
+    if (AMD) {
+      define(function () {
+        return exports;
+      });
+    }
+  }
+})();


### PR DESCRIPTION
- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Discussed on Discourse (see [here](https://discourse.nodered.org/t/input-needed-for-a-fix-in-the-dropbox-node-refresh-tokens/72949)).

## Proposed changes
Some time ago Dropbox has enforced their security.  The long live access tokens had become short live (i.e. 4 hour).  From then on a refresh token was required, which can be used to request new access tokens over and over again.

So we had introduced refresh tokens in version 2.0.0 of the Dropbox node.  That version introduced a few new endpoints, that allowed us to call functions from the Dropbox SDK to accomplish this.  And that version also used the OAuth redirect url mechanism: at the end of the OAuth2 authorization flow, the redirect url is called to pass the result (i.e. the refresh token) to Node-RED.

However Dropbox requires an SSL connection (between the flow editor and Node-RED) with certificates signed by a trusted CA, or a localhost url.  Otherwise they won't call the redirect url, since it will be considered unsecure.  Seems that a lot of users use plain HTTP, so they cannot request refresh tokens and as a result they cannot use the dropbox node anymore (see for example this [issue](https://github.com/node-red/node-red-web-nodes/issues/304)).  And of course when both the flow editor and Node-RED are located inside a secure LAN behind a firewall, stuff like that should be possible.

To solve this, I have removed all the endpoints again.  That way no Dropbox related data is being transferred to Node-RED anymore, to avoid security issues in case plain HTTP is being used.  Of course at the end the refresh token will be stored in a credential and transferred to Node-RED.

But since the endpoints were removed, I could not call the Dropbox SDK anymore.  Therefore I have implemented the same functionality in the frontend, which I previously called from the SDK.  The main problem was that the Crypto Web API SHA256 digest hash function is only available in the browser when you have a secure context, i.e. when an SSL connection to Node-RED is being used.  The browser doesn't offer that function in case of HTTP, because they want to avoid that you transfer it over plain HTTP.  However we transfer it not to Node-RED, but via SSL to Dropbox.  Since this is not an issue for our use case, a custom SHA256 hash implementation is loaded from the "resource" folder, which is being used in the frontend when the browser doesn't offer this functionality:

![image](https://user-images.githubusercontent.com/14224149/211106143-c584b229-201f-48d0-81c0-7665ae20d48b.png)

Below you can find an overview of the entire refresh token request process, which you can see is now completely managed by the dropbox node frontend code:

![image](https://user-images.githubusercontent.com/14224149/211106025-7d2afac0-ce2e-4816-b355-8bfb05c87141.png)

So this should work for both HTTP and HTTPS connections. 

## Checklist
- [ X ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ X ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
