### PR TITLE
Dropbox local resources url

### DIFF
--- a/dropbox/README.md
+++ b/dropbox/README.md
@@ -47,3 +47,30 @@ You can pass in content either as a filename by setting the **localFilename** fi
 
 The file will be uploaded to a directory on Dropbox called `Apps/{appname}/{appfolder}`
 where {appname} and {appfolder} are set when you set up the Dropbox application key and token.
+
+## Dropbox security introduction
+
+### Refresh tokens vs Access tokens
+The Dropbox security model - to protect access to your files and folders - is improved continiously, which means new versions of this node will need to be implemented to support these changes:
++ Version ***1.x*** of this node used long-live access tokens to access the files and folders of your Dropbox account.  
+  However Dropbox [announced](https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens) to retire those long-live access tokens on September 30th, 2021.  From then on Dropbox requires you to request once a long-live refresh token, which can be used infinitely do request short-live access tokens (which will be valid for only 4 hours).
++ Version ***2.0.0*** of this node was developed to support refresh tokens.  
+  This version only allowed refresh tokens to be requested from Dropbox, if your flow editor was opened via a https connection to your Node-RED system.  Moreover self signed certificates were not allowed by Dropbox.
++ Version ***2.1.0*** of this node further improved this mechanism, by allowing refresh tokens to be requested via both http and https connections to Node-RED.
+
+To request once such a refresh token, create a Dropbox config node and follow the instructions on the config node screen step by step.  The diagram below summarizes all these steps that need to be executed:
+
+![image](https://user-images.githubusercontent.com/14224149/211395697-c296134b-2f55-43dc-b5a6-73423656a39e.png)
+
+### Permissions
+The tokens only give you access to your Dropbox account, but you still need to apply permissions to these tokens.  Which means that you need to specify in your Dropbox account which actions are allowed when somebody logs in via that token.  For example:
++ `files.content.write`: Edit content of your Dropbox files and folders
++ `files.content.read`: View content of your Dropbox files and folders
+
+## Troubleshooting
+Some error messages explained:
++ `This app has reached its user limit`.  By default your Dropbox account is only accessible via one domain (e.g. http://my_node_red_domain:1880):
+
+   ![image](https://user-images.githubusercontent.com/14224149/211398030-8742ce0c-39bb-4d49-a285-bf00d9cdb9a7.png)
+
+   As a result, you will get this error when you try to access it via multiple domains.  In that case you can allow multiple clients via the above *"Enable additional users"* button.

--- a/dropbox/dropbox.html
+++ b/dropbox/dropbox.html
@@ -59,7 +59,7 @@
     </div>
 </script>
 
-<script src="https://unpkg.com/js-sha256@0.9.0/src/sha256.js"></script>
+<script src="resources/node-red-node-dropbox/sha256.js"></script>
 
 <script type="text/javascript">
 (function() {
@@ -95,7 +95,7 @@
             setTimeout(function() {
                 $("#node-dropbox-app-link").click(async function(e) {
                     e.preventDefault();
-debugger;
+
                     // The code verifier should be a high-entropy cryptographic random string with a minimum of 43 characters and a maximum of 128 characters. 
                     // It should only use A-Z, a-z, 0–9, “-”(hyphen), “.” (period), “_”(underscore), “~”(tilde) characters.
                     var PKCELength = 128;


### PR DESCRIPTION
- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
@dceejay,
I my [previous](https://github.com/node-red/node-red-web-nodes/pull/305) pull request for the dropbox node, I had already added a sha256.js file to the local 'resources' folder:

![image](https://user-images.githubusercontent.com/14224149/211666036-42eb63b1-2842-47c5-b1ec-7bddfca9a7ee.png)

That file contains a custom sha256 hash calculation function, for users that access their flow editor via a plain http connection.  Because when not using SSL, the sha256 digest function of the Web Crypto API is not accessible in e.g. Chrome.

However @twocolors mentioned that I was not using this file, but instead I was using the same file from a public web server.  I had already tested that last week, but somehow the local link got lost somewhere in my developments...

It is now fixed to get the local file (as described in the Node-RED [documentation](https://nodered.org/docs/creating-nodes/resources#loading-resources-in-the-editor)):

![image](https://user-images.githubusercontent.com/14224149/211666936-14c271f8-f37a-4db3-81a6-a4f70547a28a.png)

I have tested this, by requesting a new refresh token via a plain http connection for my flow editor.

Thanks for reviewing!!
Bart

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
