### PR TITLE
Update weather.js from One Call API 2.5 to One Call API 3.0

### DIFF
--- a/openweathermap/weather.js
+++ b/openweathermap/weather.js
@@ -51,19 +51,19 @@ module.exports = function(RED) {
             //If there is a value missing, the URL is not initialised.
             if (node.wtype === "forecast") {
                 if (node.lat && node.lon) {
-                    url = "http://api.openweathermap.org/data/2.5/forecast?lang=" + node.language + "&cnt=40&units=metric&lat=" + node.lat + "&lon=" + node.lon + "&APPID=" + node.credentials.apikey;
+                    url = "http://api.openweathermap.org/data/3.0/forecast?lang=" + node.language + "&cnt=40&units=metric&lat=" + node.lat + "&lon=" + node.lon + "&APPID=" + node.credentials.apikey;
                 } else if (node.city && node.country) {
-                    url = "http://api.openweathermap.org/data/2.5/forecast?lang=" + node.language + "&cnt=40&units=metric&q=" + node.city + "," + node.country + "&APPID=" + node.credentials.apikey;
+                    url = "http://api.openweathermap.org/data/3.0/forecast?lang=" + node.language + "&cnt=40&units=metric&q=" + node.city + "," + node.country + "&APPID=" + node.credentials.apikey;
                 }
             } else if (node.wtype === "current") {
                 if (node.lat && node.lon) {
-                    url = "http://api.openweathermap.org/data/2.5/weather?lang=" + node.language + "&lat=" + node.lat + "&lon=" + node.lon + "&APPID=" + node.credentials.apikey;
+                    url = "http://api.openweathermap.org/data/3.0/weather?lang=" + node.language + "&lat=" + node.lat + "&lon=" + node.lon + "&APPID=" + node.credentials.apikey;
                 } else if (node.city && node.country) {
-                    url = "http://api.openweathermap.org/data/2.5/weather?lang=" + node.language + "&q=" + node.city + "," + node.country + "&APPID=" + node.credentials.apikey;
+                    url = "http://api.openweathermap.org/data/3.0/weather?lang=" + node.language + "&q=" + node.city + "," + node.country + "&APPID=" + node.credentials.apikey;
                 }
             } else if (node.wtype === "onecall") {
                 if (node.lat && node.lon) {
-                    url = "https://api.openweathermap.org/data/2.5/onecall?lang=" + node.language + "&lat=" + node.lat + "&lon=" + node.lon + "&units=metric&APPID=" + node.credentials.apikey;
+                    url = "https://api.openweathermap.org/data/3.0/onecall?lang=" + node.language + "&lat=" + node.lat + "&lon=" + node.lon + "&units=metric&APPID=" + node.credentials.apikey;
                 }
             }
 


### PR DESCRIPTION
The new OneCall API 3.0 requires a subscription.
Therefore you need a credit card.
1000 calls/day are free.

The old API key for One Call 2.5 does not work for 3.0

Regards

