### PR TITLE
Fix error messages on invalid directions API requests and add a "success" node status

### DIFF
--- a/google/directions.js
+++ b/google/directions.js
@@ -156,6 +156,7 @@ module.exports = function(RED) {
                             lon: newMsg.payload.routes[0].legs[0].end_location.lon
                         }
                     };
+		    node.status({fill:"green",shape:"ring",text:"directions.status.success"});
                     cb(newMsg);
                 } else if (data.status == 'ZERO_RESULTS') {
                     newMsg = cloneMsg(msg);     //quick clone msg
@@ -187,21 +188,17 @@ module.exports = function(RED) {
                             break;
                         case 'REQUEST_DENIED':
                             error.code = 400;
-                            error.message = RED._("directions.error.request-denied");
+                 	    error.message = RED._("directions.error.request-denied");
                             break;
                         case 'UNKNOWN_ERROR':
-							error.code = 500;
+			    error.code = 500;
                             error.message = RED._("directions.error.unknown-error");
-							break;
+			    break;
                         default:
                             error.code = 500;
                             error.message = RED._("directions.error.unknown-error");
                     }
-                    throwNodeError({
-                        code: 400,
-                        message: RED._("directions.error.no-destination"),
-                        status: 'MISSING_VALUES'
-                    }, msg);
+                    throwNodeError(error, msg);
                     return;
                 }
             }

--- a/google/locales/de/directions.json
+++ b/google/locales/de/directions.json
@@ -28,7 +28,8 @@
             "name": "Name"
         },
         "status": {
-            "failed": "Fehlgeschlagen"
+            "failed": "Fehlgeschlagen",
+            "success": "Erfolgreich"
         },
         "error": {
             "no-origin": "Bitte Startpunkt angeben",

--- a/google/locales/en-US/directions.json
+++ b/google/locales/en-US/directions.json
@@ -28,7 +28,8 @@
             "name": "Name"
         },
         "status": {
-            "failed": "failed"
+            "failed": "failed",
+            "success": "success"
         },
         "error": {
             "no-origin": "Please supply an origin value",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This change adds a green node status when the request to Google API is successful. Without this change, there would be feedback on the node status only in case of errors and once the node encountered an error, the error status would be shown forever as there was no other code updating the node status. Added translations for new the "success" status as well.

It also adds proper error messages in case the request to Google API fails. Before this, it would always show the no-destination error in all cases. This looked like an oversight actually, as the error handling is in there but wasn't used.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ X ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
